### PR TITLE
Store SpCVBuffer more efficiently

### DIFF
--- a/R/ResamplingSpCVBuffer.R
+++ b/R/ResamplingSpCVBuffer.R
@@ -125,7 +125,7 @@ ResamplingSpCVBuffer = R6Class("ResamplingSpCVBuffer",
         })
         train_list = set_names(
           train_list,
-          sprintf("train_fold_%s", 1:length(train_list)))
+          sprintf("train_fold_%s", seq_along(train_list)))
       }
     },
 

--- a/R/ResamplingSpCVBuffer.R
+++ b/R/ResamplingSpCVBuffer.R
@@ -88,11 +88,11 @@ ResamplingSpCVBuffer = R6Class("ResamplingSpCVBuffer",
       pars = self$param_set$get_values()
 
       if (!isTRUE("twoclass" %in% properties) && isTRUE(pars$spDataType == "PB")) {
-        stopf("spDataType = 'PB' should only be used with two-class response")
+        stopf("spDataType = 'PB' should only be used with two-class response.")
       }
 
       if (!is.null(pars$addBG) && isTRUE(pars$spDataType == "PA")) {
-        stopf("Parameter addBG should only be used with spDataType = 'PB'")
+        stopf("Parameter addBG should only be used with spDataType = 'PB'.")
       }
 
       # Recode response to 0/1 for twoclass
@@ -110,21 +110,41 @@ ResamplingSpCVBuffer = R6Class("ResamplingSpCVBuffer",
         progress = FALSE,
         .args = pars)
 
-      mlr3misc::map(inds$folds, function(x) {
-        set = mlr3misc::map(x, function(y) {
-          ids[y]
+      # if addBG = TRUE, the test set can contain more than one element
+      if (!is.null(pars$addBG)) {
+        mlr3misc::map(inds$folds, function(x) {
+          set = mlr3misc::map(x, function(y) {
+            ids[y]
+          })
+          names(set) = c("train", "test")
+          set
         })
-        names(set) = c("train", "test")
-        set
-      })
+      } else {
+        train_list = mlr3misc::map(inds$folds, function(x) {
+          x[[1]]
+        })
+        train_list = set_names(
+          train_list,
+          sprintf("train_fold_%s", 1:length(train_list)))
+      }
     },
 
     .get_train = function(i) {
-      self$instance[[i]]$train
+      if (!is.null(self$param_set$values$addBG)) {
+
+        self$instance[[i]]$train
+      } else {
+        self$instance[[i]]
+      }
     },
 
     .get_test = function(i) {
-      self$instance[[i]]$test
+      if (!is.null(self$param_set$values$addBG)) {
+
+        self$instance[[i]]$test
+      } else {
+        i
+      }
     }
   )
 )

--- a/R/autoplot_spcv_buffer.R
+++ b/R/autoplot_spcv_buffer.R
@@ -40,8 +40,8 @@ autoplot.ResamplingSpCVBuffer = function( # nolint
 
   plot_list = list()
   for (i in fold_id) {
-    coords_train = coords[row_id %in% resampling$instance[[i]]$train]
-    coords_test = coords[row_id %in% resampling$instance[[i]]$test]
+    coords_train = coords[row_id %in% resampling$train_set(i)]
+    coords_test = coords[row_id %in% resampling$test_set(i)]
 
     coords_train$indicator = "Train"
     coords_test$indicator = "Test"
@@ -85,8 +85,8 @@ autoplot.ResamplingSpCVBuffer = function( # nolint
     ))
 
     # Extract legend standalone, we only want one legend in the grid
-    coords_train = coords[row_id %in% resampling$instance[[1]]$train]
-    coords_test = coords[row_id %in% resampling$instance[[1]]$test]
+    coords_train = coords[row_id %in% resampling$train_set(1)]
+    coords_test = coords[row_id %in% resampling$test_set(1)]
 
     coords_train$indicator = "Train"
     coords_test$indicator = "Test"


### PR DESCRIPTION
fixes #23 

If `addBG = FALSE`, we store only the dynamic train inds because the test inds are equal to the row_id (LOO).

For all other cases, we need to store both sets for each fold as the test inds are also dynamic.
However, `addBG = TRUE` should be a rare case and we should save come memory in all other instances.