### PR TITLE
Fix `blockCV::spatialBlock()` functions

### DIFF
--- a/R/ResamplingRepeatedSpCVBlock.R
+++ b/R/ResamplingRepeatedSpCVBlock.R
@@ -133,8 +133,10 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
         stopf("Grouping is not supported for spatial resampling methods.") # nocov # nolint
       }
       instance = private$.sample(
-        task$row_ids, task$coordinates(),
-        task$extra_args$crs)
+        task$row_ids,
+        task$coordinates(),
+        task$extra_args$crs
+      )
 
       self$instance = instance
       self$task_hash = task$hash
@@ -155,7 +157,7 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
   ),
 
   private = list(
-    .sample = function(ids, coords) {
+    .sample = function(ids, coords, crs) {
       pv = self$param_set$values
       folds = as.integer(pv$folds)
 

--- a/R/ResamplingRepeatedSpCVBlock.R
+++ b/R/ResamplingRepeatedSpCVBlock.R
@@ -132,7 +132,9 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
       if (!is.null(groups)) {
         stopf("Grouping is not supported for spatial resampling methods.") # nocov # nolint
       }
-      instance = private$.sample(task$row_ids, task$coordinates())
+      instance = private$.sample(
+        task$row_ids, task$coordinates(),
+        task$extra_args$crs)
 
       self$instance = instance
       self$task_hash = task$hash
@@ -158,7 +160,9 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
       folds = as.integer(pv$folds)
 
       create_blocks = function(coords, range) {
-        points = sf::st_as_sf(coords, coords = c("x", "y"))
+        points = sf::st_as_sf(coords,
+          coords = colnames(coords),
+          crs = crs)
 
         # Suppress print message, warning crs and package load
         capture.output(inds <- suppressMessages(suppressWarnings(
@@ -170,6 +174,7 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
             k = self$param_set$values$folds,
             selection = self$param_set$values$selection,
             showBlocks = FALSE,
+            verbose = FALSE,
             progress = FALSE)$foldID)))
         return(inds)
       }

--- a/R/ResamplingSpCVBuffer.R
+++ b/R/ResamplingSpCVBuffer.R
@@ -105,7 +105,7 @@ ResamplingSpCVBuffer = R6Class("ResamplingSpCVBuffer",
       }
 
       data = sf::st_as_sf(cbind(response, coords),
-        coords = c("x", "y"),
+        coords = colnames(coords),
         crs = crs)
 
       inds = invoke(blockCV::buffering,

--- a/R/TaskClassifST.R
+++ b/R/TaskClassifST.R
@@ -71,7 +71,7 @@ TaskClassifST = R6::R6Class("TaskClassifST",
         # ensure a point feature has been passed
         checkmate::assert_character(as.character(sf::st_geometry_type(backend, by_geometry = FALSE)), fixed = "POINT") # nolint
         backend = sf::st_set_geometry(backend, NULL)
-        backend = merge(backend, coordinates)
+        backend = cbind(backend, coordinates)
         extra_args$coordinate_names = colnames(coordinates)
       }
 

--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -557,7 +557,9 @@ autoplot_spatial = function(
       }
       # transform to selected crs
       sf_df = sf::st_transform(
-        sf::st_as_sf(dt, coords = c("x", "y"), crs = task$extra_args$crs),
+        sf::st_as_sf(dt,
+          coords = task$extra_args$coordinate_names,
+          crs = task$extra_args$crs),
         crs = crs)
 
       sf_df = reorder_levels(sf_df)
@@ -606,7 +608,9 @@ autoplot_spatial = function(
     }
     # transform to selected crs
     sf_df = sf::st_transform(
-      sf::st_as_sf(coords_resamp, coords = c("x", "y"), crs = task$extra_args$crs),
+      sf::st_as_sf(coords_resamp,
+        coords = task$extra_args$coordinate_names,
+        crs = task$extra_args$crs),
       crs = crs)
 
     # order fold ids
@@ -677,7 +681,9 @@ autoplot_spatiotemp = function(
   # transform coordinates to selected crs
   coords = sf::st_coordinates(
     sf::st_transform(
-      sf::st_as_sf(task$coordinates(), coords = c("x", "y"), crs = task$extra_args$crs),
+      sf::st_as_sf(task$coordinates(),
+        coords = task$extra_args$coordinate_names,
+        crs = task$extra_args$crs),
       crs = crs)
   )
   task_resamp_ids$x = coords[, 1]

--- a/R/autoplot_spcv_buffer.R
+++ b/R/autoplot_spcv_buffer.R
@@ -65,7 +65,9 @@ autoplot.ResamplingSpCVBuffer = function( # nolint
     }
     # transform to selected crs
     sf_df = sf::st_transform(
-      sf::st_as_sf(table, coords = c("x", "y"), crs = task$extra_args$crs),
+      sf::st_as_sf(table,
+        coords = task$extra_args$coordinate_names,
+        crs = task$extra_args$crs),
       crs = crs)
 
     sf_df$indicator = as.factor(as.character(sf_df$indicator))

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -11,7 +11,7 @@ test_make_sp = function() {
 # regr tasks -------------------------------------------------------------------
 
 # Create regression task
-test_make_regr = function(coords_as_features = FALSE) {
+test_make_regr_task = function(coords_as_features = FALSE) {
   data = test_make_sp()
   data$p_1 = c(rep("A", 18), rep("B", 18))
   data$response = rnorm(36)
@@ -28,6 +28,8 @@ test_make_regr = function(coords_as_features = FALSE) {
 }
 
 # Create regression task
+# similar to test_make_regr_task(), just to check if 'sf' objects work
+# as intended
 test_make_sf_regr_task = function(coords_as_features = FALSE) {
   data = test_make_sp()
   data$p_1 = c(rep("A", 18), rep("B", 18))
@@ -49,7 +51,8 @@ test_make_sf_regr_task = function(coords_as_features = FALSE) {
 # classif tasks ----------------------------------------------------------------
 
 # Create twoclass task
-test_make_twoclass = function(group = FALSE, coords_as_features = FALSE, features = "numeric") {
+test_make_twoclass_task = function(group = FALSE, coords_as_features = FALSE,
+  features = "numeric") {
 
   data = test_make_sp()
   if ("numeric" %in% features) {
@@ -82,6 +85,8 @@ test_make_twoclass = function(group = FALSE, coords_as_features = FALSE, feature
 }
 
 # Create twoclass sf task
+# similar to test_make_twoclass_task(), just to check if 'sf' objects work
+# as intended
 test_make_sf_twoclass_task = function(group = FALSE, coords_as_features = FALSE, features = "numeric") {
 
   data = test_make_sp()
@@ -114,6 +119,64 @@ test_make_sf_twoclass_task = function(group = FALSE, coords_as_features = FALSE,
   task
 }
 
+# Create twoclass sf task
+test_make_sf_twoclass_df = function(group = FALSE,
+  coords_as_features = FALSE, features = "numeric") {
+
+  data = test_make_sp()
+  if ("numeric" %in% features) {
+    data$p_1 = c(rnorm(18, 0), rnorm(18, 10))
+  }
+  if ("factor" %in% features) {
+    data$p_2 = as.factor(c(rep("lvl_1", 18), rep("lvl_2", 18)))
+  }
+  data$response = as.factor(c(rep("A", 18), rep("B", 18)))
+
+  if (group) {
+    data$group = rep_len(letters[1:10], 36)
+  }
+
+  data_sf = sf::st_as_sf(data, coords = c("x", "y"), crs = "epsg:4326")
+
+  return(data_sf)
+}
+
+# sf DF to use directly with {blockCV} functions
+test_make_blockCV_test_df = function() {
+
+  set.seed(123)
+  x <- runif(5000, -80.5, -75)
+  y <- runif(5000, 39.7, 42)
+
+  data <- data.frame(
+    spp = "test",
+    label = factor(round(runif(length(x), 0, 1))),
+    x = x,
+    y = y)
+
+  data_sf = sf::st_as_sf(data,
+    coords = c("x", "y"),
+    crs = "EPSG: 4326")
+
+  return(data_sf)
+
+}
+
+# mlr3 task to compare mlr3spatiotempcv results with {blockCV} results
+test_make_blockCV_test_task = function() {
+  data = test_make_blockCV_test_df()
+
+  task <- TaskClassifST$new(
+    id = "test",
+    backend = data,
+    target = "label",
+    positive = "1")
+  return(task)
+
+}
+
+# multiclass tasks -------------------------------------------------------------
+#
 # Create multiclass task
 test_make_multiclass = function() {
   data = test_make_sp()

--- a/tests/testthat/helper_autoplot.R
+++ b/tests/testthat/helper_autoplot.R
@@ -3,7 +3,7 @@ loadNamespace("mlr3")
 
 prepare_autoplot = function(resampling_type, task = NULL, ...) {
   if (is.null(task)) {
-    task = test_make_twoclass()
+    task = test_make_twoclass_task()
   }
   rsp = rsmp(resampling_type, ...)
   rsp$instantiate(task)

--- a/tests/testthat/test-1-autoplot.R
+++ b/tests/testthat/test-1-autoplot.R
@@ -1,7 +1,7 @@
 # generic tests
 
 test_that("errors are thrown for non-valid argument settings", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   # type does not matter here
   rsp = rsmp("spcv_coords")
   rsp$instantiate(task)

--- a/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
@@ -1,5 +1,5 @@
 test_that("folds can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", folds = 3, repeats = 2, range = c(2, 4))
   rsp$instantiate(task)
 
@@ -7,7 +7,7 @@ test_that("folds can be printed", {
 })
 
 test_that("reps can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", folds = 3, repeats = 2, range = c(2, 4))
   rsp$instantiate(task)
 
@@ -15,7 +15,7 @@ test_that("reps can be printed", {
 })
 
 test_that("resampling iterations equals folds * repeats", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", folds = 3, repeats = 2, range = c(2, 4))
   rsp$instantiate(task)
 
@@ -23,7 +23,7 @@ test_that("resampling iterations equals folds * repeats", {
 })
 
 test_that("error when neither cols & rows | range is specified", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsmp = rsmp("repeated_spcv_block", repeats = 2)
   expect_error(
     rsmp$instantiate(task),
@@ -31,7 +31,7 @@ test_that("error when neither cols & rows | range is specified", {
 })
 
 test_that("error when length(range) != length(repeats)", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", repeats = 2, range = 5)
   expect_error(
     rsp$instantiate(task),
@@ -40,13 +40,42 @@ test_that("error when length(range) != length(repeats)", {
 })
 
 test_that("no error when length(range) == repeats", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", folds = 3, repeats = 2, range = c(2, 4))
   expect_silent(rsp$instantiate(task))
 })
 
 test_that("error when number of desired folds is larger than number possible blocks", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_block", folds = 10, repeats = 2, range = c(2, 4))
   expect_error(rsp$instantiate(task))
+})
+
+test_that("mlr3spatiotempcv indices are the same as blockCV indices: cols and rows", {
+  task = test_make_blockCV_test_task()
+
+  set.seed(42)
+  rsmp <- rsmp("repeated_spcv_block",
+    repeats = 2,
+    folds = 5,
+    rows = 3,
+    cols = 4)
+  rsmp$instantiate(task)
+
+  testSF = test_make_blockCV_test_df()
+
+  set.seed(42)
+  capture.output(testBlock <- suppressMessages(
+    blockCV::spatialBlock(
+      speciesData = testSF,
+      k = 5,
+      rows = 3,
+      cols = 4,
+      showBlocks = FALSE,
+      verbose = FALSE,
+      progress = FALSE)
+  ))
+
+  # only use the first iteration
+  expect_equal(rsmp$instance$fold[1:5000], testBlock$foldID)
 })

--- a/tests/testthat/test-ResamplingRepeatedSpCVBuffer.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVBuffer.R
@@ -1,5 +1,5 @@
 test_that("resampling with twoclass response is correctly instantiated", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1)
   rsp$instantiate(task)
 
@@ -17,7 +17,7 @@ test_that("resampling with multiclass response is correctly instantiated", {
 })
 
 test_that("resampling with continuous response is correctly instantiated", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1)
   rsp$instantiate(task)
 
@@ -26,7 +26,7 @@ test_that("resampling with continuous response is correctly instantiated", {
 })
 
 test_that("buffer is corretly applied", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rcv = rsmp("spcv_buffer", theRange = 1)
   rcv$instantiate(task)
 
@@ -35,13 +35,13 @@ test_that("buffer is corretly applied", {
 })
 
 test_that("spDataType = 'PA' and addBG = TRUE throws an error", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PA", addBG = TRUE)
   expect_error(rsp$instantiate(task))
 })
 
 test_that("spDataType = 'PB' and regression task throws and error", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PB")
   expect_error(rsp$instantiate(task))
 })

--- a/tests/testthat/test-ResamplingRepeatedSpCVCoords.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVCoords.R
@@ -1,5 +1,5 @@
 test_that("folds can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_coords", folds = 3, repeats = 5)
   rsp$instantiate(task)
 
@@ -7,7 +7,7 @@ test_that("folds can be printed", {
 })
 
 test_that("reps can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_coords", folds = 3, repeats = 5)
   rsp$instantiate(task)
 
@@ -15,7 +15,7 @@ test_that("reps can be printed", {
 })
 
 test_that("resampling iterations equals folds * repeats", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_coords", folds = 3, repeats = 2)
   rsp$instantiate(task)
 

--- a/tests/testthat/test-ResamplingRepeatedSpCVEnv.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVEnv.R
@@ -1,5 +1,5 @@
 test_that("folds can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_env")
   rsp$param_set$values = list(folds = 3, repeats = 5, features = "p_1")
   rsp$instantiate(task)
@@ -8,7 +8,7 @@ test_that("folds can be printed", {
 })
 
 test_that("reps can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_env")
   rsp$param_set$values = list(folds = 3, repeats = 5, features = "p_1")
   rsp$instantiate(task)
@@ -17,7 +17,7 @@ test_that("reps can be printed", {
 })
 
 test_that("resampling iterations equals folds * repeats", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_env", folds = 2, repeats = 5, features = "p_1")
   rsp$instantiate(task)
 
@@ -27,7 +27,7 @@ test_that("resampling iterations equals folds * repeats", {
 test_that("feature p_1 seperates the observations in folds of equal size", {
   set.seed(1)
 
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_env", folds = 2, repeats = 5, features = "p_1")
   rsp$instantiate(task)
 
@@ -38,14 +38,14 @@ test_that("feature p_1 seperates the observations in folds of equal size", {
 })
 
 test_that("non-numeric feature throws an error", {
-  task = test_make_twoclass(features = c("numeric", "factor"))
+  task = test_make_twoclass_task(features = c("numeric", "factor"))
   rsp = rsmp("repeated_spcv_env", folds = 2, repeats = 5, features = "p_2")
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("non-existing feature throws an error", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_spcv_env", folds = 2, repeats = 5, features = "p_3")
 
   expect_error(rsp$instantiate(task))

--- a/tests/testthat/test-ResamplingRepeatedSptCVCstf.R
+++ b/tests/testthat/test-ResamplingRepeatedSptCVCstf.R
@@ -1,5 +1,5 @@
 test_that("folds can be printed", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("repeated_sptcv_cstf", folds = 3, repeats = 5)
   rsp$instantiate(task)
 

--- a/tests/testthat/test-ResamplingSpCVBlock.R
+++ b/tests/testthat/test-ResamplingSpCVBlock.R
@@ -1,5 +1,5 @@
 test_that("resampling iterations equals folds", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_block", folds = 2, range = 2)
   rsp$instantiate(task)
 
@@ -7,14 +7,14 @@ test_that("resampling iterations equals folds", {
 })
 
 test_that("error when number of desired folds is larger than number possible blocks", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_block", folds = 10, range = 4)
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("error when neither cols & rows | range is specified", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_block")
 
   expect_error(
@@ -23,7 +23,7 @@ test_that("error when neither cols & rows | range is specified", {
 })
 
 test_that("error when only one of rows or cols is set", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_block", rows = 4)
 
   expect_error(
@@ -34,4 +34,56 @@ test_that("error when only one of rows or cols is set", {
 
 test_that("Error when length(range) >= 2", {
   expect_error(rsmp("spcv_block", range = c(500, 1000)))
+})
+
+
+test_that("mlr3spatiotempcv indices are the same as blockCV indices: selection = checkerboard", {
+
+  # see https://github.com/mlr-org/mlr3spatiotempcv/issues/92
+
+  task = test_make_blockCV_test_task()
+
+  rsmp <- rsmp("spcv_block",
+    range = 50000,
+    selection = "checkerboard")
+  rsmp$instantiate(task)
+
+  testSF = test_make_blockCV_test_df()
+
+  capture.output(testBlock <- suppressMessages(
+    suppressWarnings(blockCV::spatialBlock(
+      speciesData = testSF,
+      theRange = 50000,
+      selection = "checkerboard",
+      showBlocks = FALSE)
+  )))
+
+  expect_equal(rsmp$instance$fold, testBlock$foldID)
+})
+
+test_that("mlr3spatiotempcv indices are the same as blockCV indices: cols and rows", {
+  task = test_make_blockCV_test_task()
+
+  set.seed(42)
+  rsmp <- rsmp("spcv_block",
+    folds = 5,
+    rows = 3,
+    cols = 4)
+  rsmp$instantiate(task)
+
+  testSF = test_make_blockCV_test_df()
+
+  set.seed(42)
+  capture.output(testBlock <- suppressMessages(
+    blockCV::spatialBlock(
+      speciesData = testSF,
+      k = 5,
+      rows = 3,
+      cols = 4,
+      showBlocks = FALSE,
+      verbose = FALSE,
+      progress = FALSE)
+  ))
+
+  expect_equal(rsmp$instance$fold, testBlock$foldID)
 })

--- a/tests/testthat/test-ResamplingSpCVBuffer.R
+++ b/tests/testthat/test-ResamplingSpCVBuffer.R
@@ -1,5 +1,5 @@
 test_that("resampling iterations equals number of observations (two-class response)", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1)
   rsp$instantiate(task)
 
@@ -15,7 +15,7 @@ test_that("resampling iterations equals number of observations (multi-class resp
 })
 
 test_that("resampling iterations equals number of observations (continuous response)", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1)
   rsp$instantiate(task)
 
@@ -23,7 +23,7 @@ test_that("resampling iterations equals number of observations (continuous respo
 })
 
 test_that("buffered observations are excludes in train set", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PA")
   rsp$instantiate(task)
 
@@ -32,7 +32,7 @@ test_that("buffered observations are excludes in train set", {
 })
 
 test_that("test sets only include positive observations", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PB", addBG = FALSE)
   rsp$instantiate(task)
 
@@ -41,7 +41,7 @@ test_that("test sets only include positive observations", {
 })
 
 test_that("test sets include background observations", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PB", addBG = TRUE)
   rsp$instantiate(task)
 
@@ -54,28 +54,28 @@ test_that("test sets include background observations", {
 })
 
 test_that("spDataType = 'PA' and addBG = TRUE throws an error", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PA", addBG = TRUE)
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("spDataType = 'PB' and continuous response throws an error", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PB")
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("spDataType = 'PB' and multi-class response throws an error", {
-  task = test_make_regr()
+  task = test_make_regr_task()
   rsp = rsmp("spcv_buffer", theRange = 1, spDataType = "PB")
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("grouping throws errors when 'groups' is set", {
-  task = test_make_twoclass(group = TRUE)
+  task = test_make_twoclass_task(group = TRUE)
   rsp = rsmp("spcv_buffer", theRange = 1)
 
   expect_error(

--- a/tests/testthat/test-ResamplingSpCVEnv.R
+++ b/tests/testthat/test-ResamplingSpCVEnv.R
@@ -1,5 +1,5 @@
 test_that("resampling iterations equals folds", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_env", folds = 2, features = "p_1")
   rsp$instantiate(task)
 
@@ -9,7 +9,7 @@ test_that("resampling iterations equals folds", {
 test_that("feature p_1 seperates the observations in two folds of equal size", {
   set.seed(1)
 
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_env", folds = 2, features = "p_1")
   rsp$instantiate(task)
 
@@ -20,14 +20,14 @@ test_that("feature p_1 seperates the observations in two folds of equal size", {
 })
 
 test_that("non-numeric feature throws an error", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_env", folds = 2, features = "p_2")
 
   expect_error(rsp$instantiate(task))
 })
 
 test_that("non-existing feature throws an error", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
   rsp = rsmp("spcv_env", folds = 2, features = "p_3")
 
   expect_error(rsp$instantiate(task))

--- a/tests/testthat/test-TaskClassifST.R
+++ b/tests/testthat/test-TaskClassifST.R
@@ -1,11 +1,11 @@
 test_that("coordinates can be used as features", {
-  task = test_make_twoclass(coords_as_features = TRUE)
+  task = test_make_twoclass_task(coords_as_features = TRUE)
 
   expect_names(c("x", "y"), subset.of = task$feature_names)
 })
 
 test_that("printing works", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
 
   expect_output(print(task))
   expect_data_table(task$coordinates())
@@ -19,7 +19,7 @@ test_that("Supplying a non-spatio temporal task gives descriptive error message"
 })
 
 test_that("coordinates can be used as features", {
-  task = test_make_twoclass(coords_as_features = TRUE)
+  task = test_make_twoclass_task(coords_as_features = TRUE)
 
   expect_names(c("x", "y"), subset.of = task$feature_names)
 })

--- a/tests/testthat/test-TaskRegrST.R
+++ b/tests/testthat/test-TaskRegrST.R
@@ -1,11 +1,11 @@
 test_that("coordinates can be used as features", {
-  task = test_make_regr(coords_as_features = TRUE)
+  task = test_make_regr_task(coords_as_features = TRUE)
 
   expect_names(c("x", "y"), subset.of = task$feature_names)
 })
 
 test_that("printing works", {
-  task = test_make_regr()
+  task = test_make_regr_task()
 
   expect_output(print(task))
   expect_data_table(task$coordinates())

--- a/tests/testthat/test-mlr_sptcv_generic.R
+++ b/tests/testthat/test-mlr_sptcv_generic.R
@@ -15,7 +15,7 @@ test_that("no duplicated ids", {
 })
 
 test_that("grouping throws errors when 'groups' is set", {
-  task = test_make_twoclass(group = TRUE)
+  task = test_make_twoclass_task(group = TRUE)
 
   spcv_rsp = rsmps(c("spcv_coords", "spcv_env"), folds = 2)
   spcv_rsp = append(spcv_rsp, rsmp("spcv_block", folds = 2, rows = 2, cols = 2))
@@ -29,7 +29,7 @@ test_that("grouping throws errors when 'groups' is set", {
 })
 
 test_that("train and test set getter functions are working", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
 
   spcv_rsp = rsmps(c("spcv_coords", "spcv_env"), folds = 2)
   spcv_rsp = append(spcv_rsp, rsmp("spcv_block", folds = 2, rows = 2, cols = 2))
@@ -43,7 +43,7 @@ test_that("train and test set getter functions are working", {
 })
 
 test_that("train and test set getter functions are working", {
-  task = test_make_twoclass()
+  task = test_make_twoclass_task()
 
   spcv_rsp = rsmps(c("repeated_spcv_coords", "repeated_spcv_env"), folds = 2)
   spcv_rsp = append(spcv_rsp, rsmp("repeated_spcv_block",


### PR DESCRIPTION
fixes #92 

The linked issue also revealed that some other {blockCV} function settings were not reproducible with {ml3spatiotempcv}.
This should now be fixed and protected by a test.

In addition this PR fixes an issue with the recently added support for {sf} objects: coordinates names from sf objects are now retrieved dynamically.
Before some functions would have errored if the coordinate names were not named "x" and "y".

``` r
library(mlr3spatiotempcv)
library(mlr3)
library(blockCV)
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1

set.seed(123)
x <- runif(5000, -80.5, -75)
y <- runif(5000, 39.7, 42)

data <- data.frame( # spp="test",
  label = factor(round(runif(length(x), 0, 1))),
  x = x,
  y = y
)

testSF <- st_as_sf(data[, c("x", "y", "label")],
  coords = c("x", "y"),
  crs = "EPSG: 4326"
)

# mlr3spatiotempcv
testTask <- TaskClassifST$new(
  id = "test",
  backend = testSF,
  target = "label",
  positive = "1"
)

blockSamp <- rsmp("spcv_block",
  # folds = 1,
  range = 50000,
  selection = "checkerboard"
)
blockSamp$instantiate(testTask)

# blockCV
testBlock <- suppressMessages(suppressWarnings(spatialBlock(
  speciesData = testSF,
  theRange = 50000,
  selection = "checkerboard",
  showBlocks = FALSE,
  verbose = FALSE
)))

print(all.equal(blockSamp$instance$fold, testBlock$foldID))
#> [1] TRUE
```

<sup>Created on 2021-03-10 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                                      
#>  version  R version 4.0.4 Patched (2021-02-17 r80031)
#>  os       macOS Big Sur 10.16                        
#>  system   x86_64, darwin17.0                         
#>  ui       X11                                        
#>  language (EN)                                       
#>  collate  en_US.UTF-8                                
#>  ctype    en_US.UTF-8                                
#>  tz       Europe/Zurich                              
#>  date     2021-03-10                                 
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package          * version    date       lib source                       
#>  assertthat         0.2.1      2019-03-21 [1] standard (@0.2.1)            
#>  backports          1.2.1      2020-12-09 [1] RSPM (R 4.0.4)               
#>  blockCV          * 2.1.1      2020-02-23 [1] CRAN (R 4.0.4)               
#>  checkmate          2.0.0      2020-02-06 [1] RSPM (R 4.0.4)               
#>  class              7.3-18     2021-01-24 [2] CRAN (R 4.0.4)               
#>  classInt           0.4-3      2020-04-07 [1] CRAN (R 4.0.4)               
#>  cli                2.3.1      2021-02-23 [1] CRAN (R 4.0.4)               
#>  codetools          0.2-18     2020-11-04 [2] CRAN (R 4.0.4)               
#>  colorspace         2.0-0      2020-11-11 [1] CRAN (R 4.0.4)               
#>  crayon             1.4.1      2021-02-08 [1] standard (@1.4.1)            
#>  data.table         1.14.0     2021-02-21 [1] standard (@1.14.0)           
#>  DBI                1.1.1      2021-01-15 [1] CRAN (R 4.0.4)               
#>  digest             0.6.27     2020-10-24 [1] standard (@0.6.27)           
#>  dplyr              1.0.5      2021-03-05 [1] CRAN (R 4.0.4)               
#>  e1071              1.7-4      2020-10-14 [1] CRAN (R 4.0.4)               
#>  ellipsis           0.3.1      2020-05-15 [1] standard (@0.3.1)            
#>  evaluate           0.14       2019-05-28 [1] standard (@0.14)             
#>  fansi              0.4.2      2021-01-15 [1] standard (@0.4.2)            
#>  fs                 1.5.0      2020-07-31 [1] standard (@1.5.0)            
#>  generics           0.1.0      2020-10-31 [1] standard (@0.1.0)            
#>  ggplot2            3.3.3      2020-12-30 [1] CRAN (R 4.0.4)               
#>  glue               1.4.2      2020-08-27 [1] standard (@1.4.2)            
#>  gtable             0.3.0      2019-03-25 [1] CRAN (R 4.0.4)               
#>  highr              0.8        2019-03-20 [1] standard (@0.8)              
#>  hms                1.0.0      2021-01-13 [1] standard (@1.0.0)            
#>  htmltools          0.5.1.1    2021-01-22 [1] standard (@0.5.1.1)          
#>  KernSmooth         2.23-18    2020-10-29 [2] CRAN (R 4.0.4)               
#>  knitr              1.31       2021-01-27 [1] standard (@1.31)             
#>  lattice            0.20-41    2020-04-02 [2] CRAN (R 4.0.4)               
#>  lgr                0.4.2      2021-01-10 [1] CRAN (R 4.0.4)               
#>  lifecycle          1.0.0      2021-02-15 [1] standard (@1.0.0)            
#>  magrittr           2.0.1      2020-11-17 [1] standard (@2.0.1)            
#>  mlr3             * 0.11.0     2021-03-05 [1] CRAN (R 4.0.4)               
#>  mlr3misc           0.7.0      2021-01-05 [1] CRAN (R 4.0.4)               
#>  mlr3spatiotempcv * 0.2.0.9000 2021-03-10 [1] local                        
#>  munsell            0.5.0      2018-06-12 [1] CRAN (R 4.0.4)               
#>  palmerpenguins     0.1.0      2020-07-23 [1] CRAN (R 4.0.4)               
#>  paradox            0.7.1      2021-03-07 [1] CRAN (R 4.0.4)               
#>  parallelly         1.23.0     2021-01-04 [1] CRAN (R 4.0.4)               
#>  pillar             1.5.0      2021-02-22 [1] standard (@1.5.0)            
#>  pkgconfig          2.0.3      2019-09-22 [1] standard (@2.0.3)            
#>  prettyunits        1.1.1      2020-01-24 [1] standard (@1.1.1)            
#>  progress           1.2.2      2019-05-16 [1] CRAN (R 4.0.4)               
#>  purrr              0.3.4      2020-04-17 [1] standard (@0.3.4)            
#>  R.cache            0.14.0     2019-12-06 [1] RSPM (R 4.0.4)               
#>  R.methodsS3        1.8.1      2020-08-26 [1] RSPM (R 4.0.4)               
#>  R.oo               1.24.0     2020-08-26 [1] RSPM (R 4.0.4)               
#>  R.utils            2.10.1     2020-08-26 [1] RSPM (R 4.0.4)               
#>  R6                 2.5.0      2020-10-28 [1] standard (@2.5.0)            
#>  raster             3.4-5      2020-11-14 [1] CRAN (R 4.0.4)               
#>  Rcpp               1.0.6      2021-01-15 [1] standard (@1.0.6)            
#>  rematch2           2.1.2      2020-05-01 [1] standard (@2.1.2)            
#>  reprex             1.0.0      2021-01-27 [1] standard (@1.0.0)            
#>  rgdal              1.5-23     2021-02-03 [1] CRAN (R 4.0.4)               
#>  rlang              0.4.10     2020-12-30 [1] standard (@0.4.10)           
#>  rmarkdown          2.7        2021-02-19 [1] CRAN (R 4.0.4)               
#>  scales             1.1.1      2020-05-11 [1] CRAN (R 4.0.4)               
#>  sessioninfo        1.1.1      2018-11-05 [1] standard (@1.1.1)            
#>  sf               * 0.9-7      2021-01-06 [1] CRAN (R 4.0.4)               
#>  sp                 1.4-5      2021-01-10 [1] CRAN (R 4.0.4)               
#>  stringi            1.5.3      2020-09-09 [1] standard (@1.5.3)            
#>  stringr            1.4.0      2019-02-10 [1] standard (@1.4.0)            
#>  styler             1.3.2.9000 2021-03-04 [1] Github (pat-s/styler@51d5200)
#>  tibble             3.1.0      2021-02-25 [1] standard (@3.1.0)            
#>  tidyselect         1.1.0      2020-05-11 [1] CRAN (R 4.0.4)               
#>  units              0.7-0      2021-02-25 [1] CRAN (R 4.0.4)               
#>  utf8               1.1.4      2018-05-24 [1] standard (@1.1.4)            
#>  uuid               0.1-4      2020-02-26 [1] CRAN (R 4.0.4)               
#>  vctrs              0.3.6      2020-12-17 [1] standard (@0.3.6)            
#>  withr              2.4.1      2021-01-26 [1] standard (@2.4.1)            
#>  xfun               0.21       2021-02-10 [1] standard (@0.21)             
#>  yaml               2.2.1      2020-02-01 [1] standard (@2.2.1)            
#> 
#> [1] /Users/pjs/Library/R/4.0/library
#> [2] /Library/Frameworks/R.framework/Versions/4.0/Resources/library
```

</details>