### PR TITLE
Fix row duplication when creating TaskRegrST tasks from sf objects

### DIFF
--- a/R/TaskRegrST.R
+++ b/R/TaskRegrST.R
@@ -42,7 +42,7 @@ TaskRegrST = R6::R6Class("TaskRegrST",
         # ensure a point feature has been passed
         checkmate::assert_character(as.character(sf::st_geometry_type(backend, by_geometry = FALSE)), fixed = "POINT") # nolint
         backend = sf::st_set_geometry(backend, NULL)
-        backend = merge(backend, coordinates)
+        backend = cbind(backend, coordinates)
         extra_args$coordinate_names = colnames(coordinates)
       }
 

--- a/tests/testthat/test-TaskClassifST.R
+++ b/tests/testthat/test-TaskClassifST.R
@@ -39,3 +39,20 @@ test_that("sf objects can be used for task creation", {
   expect_data_table(task$coordinates())
   expect_output(print(task$truth()))
 })
+
+# https://github.com/mlr-org/mlr3spatiotempcv/issues/151
+test_that("tasks created from sf objects do not duplicate rows", {
+  data = test_make_sf_twoclass_df()
+
+  task = TaskClassifST$new(
+    id = "sp_regression",
+    backend = data,
+    target = "response",
+    extra_args = list(
+      coordinate_names = c("x", "y"),
+      crs = "+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs",
+      coords_as_features = FALSE)
+  )
+
+  expect_equal(nrow(task$data()), nrow(data))
+})

--- a/tests/testthat/test-TaskRegrST.R
+++ b/tests/testthat/test-TaskRegrST.R
@@ -11,3 +11,22 @@ test_that("printing works", {
   expect_data_table(task$coordinates())
   expect_output(print(task$truth()))
 })
+
+# https://github.com/mlr-org/mlr3spatiotempcv/issues/151
+test_that("tasks created from sf objects do not duplicate rows", {
+  data = test_make_sp()
+  data$p_1 = c(rep("A", 18), rep("B", 18))
+  data$response = rnorm(36)
+
+  task = TaskRegrST$new(
+    id = "sp_regression",
+    backend = data,
+    target = "response",
+    extra_args = list(
+      coordinate_names = c("x", "y"),
+      crs = "+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs",
+      coords_as_features = FALSE)
+  )
+
+  expect_equal(nrow(task$data()), nrow(data))
+})


### PR DESCRIPTION
fixes #151 

Probably caused by [this behaviour](https://stat.ethz.ch/pipermail/r-help/2012-February/302657.html) in `merge()`.