### PR TITLE
Allow creating tasks from `sf` objects via constructor

### DIFF
--- a/R/TaskClassifST.R
+++ b/R/TaskClassifST.R
@@ -93,7 +93,7 @@ TaskClassifST = R6::R6Class("TaskClassifST",
     #'
     #' @return [data.table::data.table()]
     coordinates = function(row_ids = NULL) {
-      if (is.null(row_ids)) row_ids <- self$row_ids
+      if (is.null(row_ids)) row_ids = self$row_ids
       self$backend$data(rows = row_ids, cols = self$coordinate_names)
     },
 

--- a/R/TaskClassifST.R
+++ b/R/TaskClassifST.R
@@ -26,8 +26,10 @@
 #' @export
 #' @examples
 #' if (mlr3misc::require_namespaces(c("sf", "blockCV"), quietly = TRUE)) {
-#'   task = as_task_classif_st(ecuador, target = "slides",
-#'     positive = "TRUE", coordinate_names = c("x", "y"))
+#'   task = as_task_classif_st(ecuador,
+#'     target = "slides",
+#'     positive = "TRUE", coordinate_names = c("x", "y")
+#'   )
 #'
 #'   # passing objects of class 'sf' is also supported
 #'   data_sf = sf::st_as_sf(ecuador, coords = c("x", "y"))
@@ -50,9 +52,19 @@ TaskClassifST = R6::R6Class("TaskClassifST",
     initialize = function(id, backend, target, positive = NULL,
       label = NA_character_, coordinate_names, crs = NA_character_,
       coords_as_features = FALSE, extra_args = list()) {
+      if (inherits(backend, "sf")) {
+        # extract spatial meta data
+        crs = sf::st_crs(backend)$input
+        coordinates = as.data.frame(sf::st_coordinates(backend))
+        coordinate_names = colnames(coordinates)
 
-      super$initialize(id = id, backend = backend, target = target,
-        positive = positive, extra_args = extra_args)
+        backend = format_sf(backend)
+      }
+
+      super$initialize(
+        id = id, backend = backend, target = target,
+        positive = positive, extra_args = extra_args
+      )
 
       self$crs = crs
       self$coordinate_names = coordinate_names
@@ -65,8 +77,10 @@ TaskClassifST = R6::R6Class("TaskClassifST",
       self$coords_as_features = assert_flag(coords_as_features)
 
       new_col_roles = named_list(
-        setdiff(mlr_reflections$task_col_roles[["classif_st"]],
-          names(private$.col_roles)), character(0)
+        setdiff(
+          mlr_reflections$task_col_roles[["classif_st"]],
+          names(private$.col_roles)
+        ), character(0)
       )
       private$.col_roles = insert_named(private$.col_roles, new_col_roles)
     },
@@ -79,7 +93,7 @@ TaskClassifST = R6::R6Class("TaskClassifST",
     #'
     #' @return [data.table::data.table()]
     coordinates = function(row_ids = NULL) {
-      if (is.null(row_ids)) row_ids = self$row_ids
+      if (is.null(row_ids)) row_ids <- self$row_ids
       self$backend$data(rows = row_ids, cols = self$coordinate_names)
     },
 
@@ -97,11 +111,15 @@ TaskClassifST = R6::R6Class("TaskClassifST",
           sprintf("  - Space: %s", self$col_roles$space)
         ))
       } else if (length(self$col_roles$time)) {
-        catn(c("* Column roles:",
-          sprintf("  - Time: %s", self$col_roles$time)))
+        catn(c(
+          "* Column roles:",
+          sprintf("  - Time: %s", self$col_roles$time)
+        ))
       } else if (length(self$col_roles$space)) {
-        catn(c("* Column roles:",
-          sprintf("  - Space: %s", self$col_roles$space)))
+        catn(c(
+          "* Column roles:",
+          sprintf("  - Space: %s", self$col_roles$space)
+        ))
       }
     }
   ),
@@ -122,8 +140,10 @@ TaskClassifST = R6::R6Class("TaskClassifST",
       if (missing(rhs)) {
         return(self$extra_args$coordinate_names)
       }
-      self$extra_args$coordinate_names = assert_character(rhs, len = 2,
-        all.missing = FALSE, any.missing = FALSE)
+      self$extra_args$coordinate_names = assert_character(rhs,
+        len = 2,
+        all.missing = FALSE, any.missing = FALSE
+      )
     },
 
     #' @field coords_as_features (`logical(1)`)\cr

--- a/R/TaskRegrST.R
+++ b/R/TaskRegrST.R
@@ -32,6 +32,15 @@ TaskRegrST = R6::R6Class("TaskRegrST",
     initialize = function(id, backend, target, label = NA_character_,
       coordinate_names, crs = NA_character_, coords_as_features = FALSE,
       extra_args = list()) {
+      if (inherits(backend, "sf")) {
+        # extract spatial meta data
+        crs = sf::st_crs(backend)$input
+        coordinates = as.data.frame(sf::st_coordinates(backend))
+        coordinate_names = colnames(coordinates)
+
+        backend = format_sf(backend)
+      }
+
       super$initialize(
         id = id, backend = backend, target = target,
         extra_args = extra_args
@@ -63,7 +72,7 @@ TaskRegrST = R6::R6Class("TaskRegrST",
     #'
     #' @return [data.table::data.table()]
     coordinates = function(row_ids = NULL) {
-      if (is.null(row_ids)) row_ids = self$row_ids
+      if (is.null(row_ids)) row_ids <- self$row_ids
       self$backend$data(rows = row_ids, cols = self$coordinate_names)
     },
 
@@ -81,11 +90,15 @@ TaskRegrST = R6::R6Class("TaskRegrST",
           sprintf("  - Space: %s", self$col_roles$space)
         ))
       } else if (length(self$col_roles$time)) {
-        catn(c("* Column roles:",
-          sprintf("  - Time: %s", self$col_roles$time)))
+        catn(c(
+          "* Column roles:",
+          sprintf("  - Time: %s", self$col_roles$time)
+        ))
       } else if (length(self$col_roles$space)) {
-        catn(c("* Column roles:",
-          sprintf("  - Space: %s", self$col_roles$space)))
+        catn(c(
+          "* Column roles:",
+          sprintf("  - Space: %s", self$col_roles$space)
+        ))
       }
     }
   ),
@@ -106,8 +119,10 @@ TaskRegrST = R6::R6Class("TaskRegrST",
       if (missing(rhs)) {
         return(self$extra_args$coordinate_names)
       }
-      self$extra_args$coordinate_names = assert_character(rhs, len = 2,
-        all.missing = FALSE, any.missing = FALSE)
+      self$extra_args$coordinate_names = assert_character(rhs,
+        len = 2,
+        all.missing = FALSE, any.missing = FALSE
+      )
     },
 
     #' @field coords_as_features (`logical(1)`)\cr

--- a/R/as_task_classif_st.R
+++ b/R/as_task_classif_st.R
@@ -86,24 +86,15 @@ as_task_classif_st.DataBackend = function(x, target,
 as_task_classif_st.sf = function(x, target = NULL, id = deparse(substitute(x)),
   positive = NULL, coords_as_features = FALSE, label = NA_character_, ...) {
   id = as.character(id)
-  geometries = as.character(unique(sf::st_geometry_type(x)))
-  if (!test_names(geometries, identical.to = "POINT")) {
-    stop("Simple feature may not contain geometries of type '%s'",
-      str_collapse(setdiff(geometries, "POINT")))
+
+  if (inherits(x, "sf")) {
+    # extract spatial meta data
+    crs = sf::st_crs(x)$input
+    coordinates = as.data.frame(sf::st_coordinates(x))
+    coordinate_names = colnames(coordinates)
+
+    x = format_sf(x)
   }
-
-  # extract spatial meta data
-  crs = sf::st_crs(x)$input
-  coordinates = as.data.frame(sf::st_coordinates(x))
-  coordinate_names = colnames(coordinates)
-
-  # convert sf to data.frame
-  x[[attr(x, "sf_column")]] = NULL
-  attr(x, "sf_column") = NULL
-  x = as.data.frame(x)
-
-  # add coordinates
-  x = cbind(x, coordinates)
 
   as_task_classif_st(x, target = target, id = id, positive = positive,
     coords_as_features = coords_as_features, crs = crs,

--- a/R/as_task_regr_st.R
+++ b/R/as_task_regr_st.R
@@ -86,24 +86,15 @@ as_task_regr_st.DataBackend = function(x, target, id = deparse(substitute(x)),
 as_task_regr_st.sf = function(x, target = NULL, id = deparse(substitute(x)),
   coords_as_features = FALSE, label = NA_character_, ...) {
   id = as.character(id)
-  geometries = as.character(unique(sf::st_geometry_type(x)))
-  if (!test_names(geometries, identical.to = "POINT")) {
-    stop("Simple feature may not contain geometries of type '%s'",
-      str_collapse(setdiff(geometries, "POINT")))
+
+  if (inherits(x, "sf")) {
+    # extract spatial meta data
+    crs = sf::st_crs(x)$input
+    coordinates = as.data.frame(sf::st_coordinates(x))
+    coordinate_names = colnames(coordinates)
+
+    x = format_sf(x)
   }
-
-  # extract spatial meta data
-  crs = sf::st_crs(x)$input
-  coordinates = as.data.frame(sf::st_coordinates(x))
-  coordinate_names = colnames(coordinates)
-
-  # convert sf to data.frame
-  x[[attr(x, "sf_column")]] = NULL
-  attr(x, "sf_column") = NULL
-  x = as.data.frame(x)
-
-  # add coordinates
-  x = cbind(x, coordinates)
 
   as_task_regr_st(x, target = target, id = id,
     coords_as_features = coords_as_features, crs = crs,

--- a/R/helper.R
+++ b/R/helper.R
@@ -8,25 +8,29 @@ check_cluto_path = function() {
     vcluster_loc = switch(Sys.info()[["sysname"]],
       "Windows" = {
         if (!file.exists(system.file("vcluster.exe", # nocov start
-          package = "mlr3spatiotempcv"))) {
+          package = "mlr3spatiotempcv"
+        ))) {
           stopf("vcluster.exe not found. Please install CLUTO first.
             See ?ResamplingSptCVCluto for instructions.", wrap = TRUE)
         }
         normalizePath(system.file("vcluster.exe",
-          package = "mlr3spatiotempcv"))
+          package = "mlr3spatiotempcv"
+        ))
       }, # nocov end
       "Linux" = {
         if (Sys.info()[["machine"]] != "x86_64") {
           stopf("CLUTO on Linux only works on x86_64 architecture.")
         }
         if (!file.exists(system.file("vcluster",
-          package = "mlr3spatiotempcv"))) {
+          package = "mlr3spatiotempcv"
+        ))) {
           stopf("vcluster executable not found. Please install CLUTO first.
             See ?ResamplingSptCVCluto for instructions.", wrap = TRUE)
         }
         # nocov start
         system.file("vcluster",
-          package = "mlr3spatiotempcv")
+          package = "mlr3spatiotempcv"
+        )
         # nocov end
       },
       "Darwin" = stopf("macOS is not supported by method 'CLUTO'.")
@@ -37,4 +41,27 @@ check_cluto_path = function() {
 
 catn = function(..., file = "") {
   cat(paste0(..., collapse = "\n"), "\n", sep = "", file = file)
+}
+
+# formats an sf object into a data.frame to be used with for Task creation
+format_sf = function(data) {
+  geometries = as.character(unique(sf::st_geometry_type(data)))
+  if (!test_names(geometries, identical.to = "POINT")) {
+    stop(
+      "Simple feature may not contain geometries of type '%s'",
+      str_collapse(setdiff(geometries, "POINT"))
+    )
+  }
+
+  # extract spatial meta data
+  coordinates = as.data.frame(sf::st_coordinates(data))
+
+  # convert sf to data.frame
+  data[[attr(data, "sf_column")]] = NULL
+  attr(data, "sf_column") = NULL
+  data = as.data.frame(data)
+
+  # add coordinates
+  data = cbind(data, coordinates)
+  return(data)
 }

--- a/tests/testthat/test-TaskClassifST.R
+++ b/tests/testthat/test-TaskClassifST.R
@@ -15,7 +15,8 @@ test_that("printing works", {
 test_that("Supplying a non-spatio temporal task gives descriptive error message", {
   expect_error(
     rsmp("spcv_coords")$instantiate(tsk("boston_housing")),
-    "Must inherit from class 'TaskClassifST' or 'TaskRegrST'.") # nolint
+    "Must inherit from class 'TaskClassifST' or 'TaskRegrST'."
+  ) # nolint
 })
 
 test_that("coordinates can be used as features", {
@@ -68,7 +69,25 @@ test_that("extra_args contains default arguments", {
     coordinate_names = c("x", "y")
   )
 
-  expect_equal(task$extra_args, list(crs = NA_character_,
+  expect_equal(task$extra_args, list(
+    crs = NA_character_,
     coordinate_names = c("x", "y"), coords_as_features = FALSE
   ))
+})
+
+test_that("Task creation works via constructor and sf object", {
+  data_sf = sf::st_as_sf(ecuador, coords = c("x", "y"))
+
+  # create mlr3 task
+  task = TaskClassifST$new("ecuador_sf",
+    backend = data_sf, target = "slides", positive = "TRUE"
+  )
+
+  task_as = as_task_classif_st(data_sf,
+    id = "ecuador_sf",
+    target = "slides", positive = "TRUE"
+  )
+
+
+  expect_equal(task, task_as, ignore_attr = "hash")
 })

--- a/tests/testthat/test-TaskRegrST.R
+++ b/tests/testthat/test-TaskRegrST.R
@@ -45,3 +45,26 @@ test_that("extra_args contains default arguments", {
     coordinate_names = c("x", "y"), coords_as_features = FALSE
   ))
 })
+
+test_that("Task creation works via constructor and sf object", {
+  data = test_make_sp()
+  data$p_1 = c(rep("A", 18), rep("B", 18))
+  data$response = rnorm(36)
+
+  data_sf = sf::st_as_sf(data, coords = c("x", "y"))
+
+  # create mlr3 task via constructor
+  task = TaskRegrST$new("ecuador_sf",
+    backend = data_sf,
+    target = "response"
+  )
+
+  task_as = as_task_regr_st(data_sf,
+    id = "ecuador_sf",
+    backend = data_sf,
+    target = "response"
+  )
+
+
+  expect_equal(task, task_as, ignore_attr = "hash")
+})

--- a/vignettes/mlr3spatiotempcv.Rmd
+++ b/vignettes/mlr3spatiotempcv.Rmd
@@ -29,9 +29,9 @@ This package adds resampling methods for the {mlr3} package framework suited for
 These methods can help to reduce the influence of [autocorrelation](https://mlr3book.mlr-org.com/08-special-spatiotemp.html#spatiotemporal-intro) on performance estimates when performing cross-validation.
 While this article gives a rather technical introduction to the package, a more applied approach can be found in the [mlr3book section on "Spatiotemporal Analysis"](https://mlr3book.mlr-org.com/08-special-spatiotemp.html).
 
-After loading the package via `library("mlr3spatiotempcv`, the spatiotemporal resampling methods and example tasks provided by {mlr3spatiotempcv} are available to the user **alongside the default {mlr3} resampling methods and tasks**.
+After loading the package via `library("mlr3spatiotempcv")`, the spatiotemporal resampling methods and example tasks provided by {mlr3spatiotempcv} are available to the user **alongside the default {mlr3} resampling methods and tasks**.
 
-## Creating a Spatial Task
+## Creating a spatial Task
 
 To make use of spatial resampling methods, a {mlr3} task that is aware of its spatial characteristic needs to be created.
 Two child classes of `Task` exist in {mlr3spatiotempcv} for this purpose:
@@ -127,8 +127,8 @@ See `as.data.table(mlr_resamplings)` for the full dictionary.
 
 Additional example tasks:
 
-- `tsk("ecuador` (spatial, classif)
-- `tsk("cookfarm_mlr3` (spatiotemp, regr)
+- `tsk("ecuador")` (spatial, classif)
+- `tsk("cookfarm_mlr3")` (spatiotemp, regr)
 
 # Upstream Packages and Scientific References
 
@@ -154,9 +154,9 @@ All methods besides `"spcv_buffer"` also have a corresponding "repeated" method.
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
 | **Grouping**, predefined inds  | (mlr3) Predefined partitions                  |        -          | `mlr_resamplings_custom_cv`                  |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
-| **Grouping**, spatiotemporal   | (mlr3) via `col_roles` `"group"`              |        -          | `mlr_resamplings_cv`, `Task$set_col_roles(<variable, "group` |
+| **Grouping**, spatiotemporal   | (mlr3) via `col_roles` `"group"`              |        -          | `mlr_resamplings_cv`, `Task$set_col_roles(<variable, "group")` |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
-| **Grouping**, spatiotemporal   | (CAST) Leave-Location-and-Time-Out            | @meyer2018        | `mlr_resamplings_sptcv_cstf`, `Task$set_col_roles(<variable>, "space|time`              |
+| **Grouping**, spatiotemporal   | (CAST) Leave-Location-and-Time-Out            | @meyer2018        | `mlr_resamplings_sptcv_cstf`, `Task$set_col_roles(<variable>, "space|time")`              |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
 | **Clustering**, spatiotemporal | (skmeans) Spatiotemporal Clustering           | @zhao2002         | `mlr_resamplings_sptcv_cluto`                |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+

--- a/vignettes/mlr3spatiotempcv.Rmd
+++ b/vignettes/mlr3spatiotempcv.Rmd
@@ -29,41 +29,48 @@ This package adds resampling methods for the {mlr3} package framework suited for
 These methods can help to reduce the influence of [autocorrelation](https://mlr3book.mlr-org.com/08-special-spatiotemp.html#spatiotemporal-intro) on performance estimates when performing cross-validation.
 While this article gives a rather technical introduction to the package, a more applied approach can be found in the [mlr3book section on "Spatiotemporal Analysis"](https://mlr3book.mlr-org.com/08-special-spatiotemp.html).
 
-After loading the package via `library("mlr3spatiotempcv")`, the spatiotemporal resampling methods and example tasks provided by {mlr3spatiotempcv} are available to the user **alongside the default {mlr3} resampling methods and tasks**.
+After loading the package via `library("mlr3spatiotempcv`, the spatiotemporal resampling methods and example tasks provided by {mlr3spatiotempcv} are available to the user **alongside the default {mlr3} resampling methods and tasks**.
 
-## Creating a spatial Task
+## Creating a Spatial Task
 
 To make use of spatial resampling methods, a {mlr3} task that is aware of its spatial characteristic needs to be created.
-Two child classes exist in {mlr3spatiotempcv} for this purpose:
+Two child classes of `Task` exist in {mlr3spatiotempcv} for this purpose:
 
-- `TaskClassifST$new()`
-- `TaskRegrST$new()`
+- `TaskClassifST`
+- `TaskRegrST`
 
-To create one of these, one can either pass a `sf` object as the "backend" directly:
+To create one of these, you have multiple options:
 
-```r
+1. Use the constructor of the `Task` directly via `$new()`
+1. Use the `as_task_*` converters
+
+We recommend the latter, as these converters aim to make Task construction easier, e.g. by creating the `DataBackend` automatically and setting the `crs` and `coordinate_names` fields.
+Let's assume you start with an `sf` object, which is a common start scenario for spatial analysis in R:
+
+```{r 08-special-spatiotemp-002}
 # create 'sf' object
-data_sf = sf::st_as_sf(ecuador, coords = c("x", "y"))
+data_sf = sf::st_as_sf(ecuador, coords = c("x", "y"), crs = 32717)
 
-# create mlr3 task
-task = TaskClassifST$new("ecuador_sf",
-  backend = data_sf, target = "slides", positive = "TRUE"
-)
+task = as_task_classif_st(data_sf, id = "ecuador_task",
+  target = "slides", positive = "TRUE")
 ```
 
-or use a plain `data.frame`.
-In this case, the constructor of `TaskClassifST` needs a few more arguments:
+You can also use a plain `data.frame`.
+In this case, `crs` and `coordinate_names` need to be passed along explicitly as they cannot be inferred from the `sf` object as in the previous example:
 
-```r
-data = mlr3::as_data_backend(ecuador)
-task = TaskClassifST$new("ecuador",
-  backend = data, target = "slides",
-  positive = "TRUE", extra_args = list(coordinate_names = c("x", "y"))
-)
+```{r 08-special-spatiotemp-003}
+task = as_task_classif_st(ecuador, id = "ecuador_task",
+  target = "slides", positive = "TRUE",
+  coordinate_names = c("x", "y"), crs = 32717)
 ```
 
-Now this Task can be used as a normal {mlr3} task in any kind of modeling scenario.
-Have a look at the [mlr3book section on "Spatiotemporal Analysis"](https://mlr3book.mlr-org.com/08-special-spatiotemp.html) on how to apply a spatiotemporal resampling method to such a task.
+The `*ST` task family prints a subset of the coordinates by default:
+
+```{r 08-special-spatiotemp-004}
+task
+```
+
+All `*ST` tasks can be treated as their super class equivalents `TaskClassif` or `TaskRegr` in any upcoming modeling step.
 
 # Contributed reflections by {mlr3spatiotempcv}
 
@@ -120,8 +127,8 @@ See `as.data.table(mlr_resamplings)` for the full dictionary.
 
 Additional example tasks:
 
-- `tsk("ecuador")` (spatial, classif)
-- `tsk("cookfarm_mlr3")` (spatiotemp, regr)
+- `tsk("ecuador` (spatial, classif)
+- `tsk("cookfarm_mlr3` (spatiotemp, regr)
 
 # Upstream Packages and Scientific References
 
@@ -147,9 +154,9 @@ All methods besides `"spcv_buffer"` also have a corresponding "repeated" method.
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
 | **Grouping**, predefined inds  | (mlr3) Predefined partitions                  |        -          | `mlr_resamplings_custom_cv`                  |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
-| **Grouping**, spatiotemporal   | (mlr3) via `col_roles` `"group"`              |        -          | `mlr_resamplings_cv`, `Task$set_col_roles(<variable, "group")` |
+| **Grouping**, spatiotemporal   | (mlr3) via `col_roles` `"group"`              |        -          | `mlr_resamplings_cv`, `Task$set_col_roles(<variable, "group` |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
-| **Grouping**, spatiotemporal   | (CAST) Leave-Location-and-Time-Out            | @meyer2018        | `mlr_resamplings_sptcv_cstf`, `Task$set_col_roles(<variable>, "space|time")`              |
+| **Grouping**, spatiotemporal   | (CAST) Leave-Location-and-Time-Out            | @meyer2018        | `mlr_resamplings_sptcv_cstf`, `Task$set_col_roles(<variable>, "space|time`              |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+
 | **Clustering**, spatiotemporal | (skmeans) Spatiotemporal Clustering           | @zhao2002         | `mlr_resamplings_sptcv_cluto`                |
 +--------------------------------+-----------------------------------------------+-------------------+--------------------------------------+


### PR DESCRIPTION
fixes #203 

- move logic into helper fun `format_sf`
- evaluate code parts in vignette
- add tests

cc @be-marc 