### PR TITLE
API-compliant handling of `sf` objects in Task Constructor

### DIFF
--- a/R/TaskRegrST.R
+++ b/R/TaskRegrST.R
@@ -32,19 +32,18 @@ TaskRegrST = R6::R6Class("TaskRegrST",
     initialize = function(id, backend, target, label = NA_character_,
       coordinate_names, crs = NA_character_, coords_as_features = FALSE,
       extra_args = list()) {
-      if (inherits(backend, "sf")) {
-        # extract spatial meta data
-        crs = sf::st_crs(backend)$input
-        coordinates = as.data.frame(sf::st_coordinates(backend))
-        coordinate_names = colnames(coordinates)
-
-        backend = format_sf(backend)
-      }
 
       super$initialize(
         id = id, backend = backend, target = target,
         extra_args = extra_args
       )
+
+      if (inherits(backend, "sf")) {
+        # extract spatial meta data from sf backend
+        crs = sf::st_crs(backend)$input
+        coordinates = as.data.frame(sf::st_coordinates(backend))
+        coordinate_names = colnames(coordinates)
+      }
 
       self$crs = crs
       self$coordinate_names = coordinate_names

--- a/R/as_data_backend.R
+++ b/R/as_data_backend.R
@@ -1,0 +1,32 @@
+#' @importFrom mlr3 as_data_backend
+#' @rdname as_data_backend
+#' @export as_data_backend.sf
+#' @exportS3Method
+as_data_backend.sf = function(data, primary_key = NULL, ...) {
+  data = format_sf(data)
+
+  if (is.character(primary_key)) {
+    assert_string(primary_key)
+    assert_choice(primary_key, colnames(data))
+    assert_integer(data[[primary_key]], any.missing = FALSE, unique = TRUE)
+  } else {
+    if (is.null(primary_key)) {
+      row_ids = seq_row(data)
+      compact_seq = TRUE
+    } else if (is.integer(primary_key)) {
+      row_ids = assert_integer(primary_key, len = nrow(data), any.missing = FALSE, unique = TRUE)
+    } else {
+      stopf("Argument 'primary_key' must be NULL, a column name or a vector of ids")
+    }
+
+    primary_key = "..row_id"
+    data = insert_named(data, list("..row_id" = row_ids))
+  }
+
+  compact_seq = FALSE
+
+  b = DataBackendDataTable$new(data, primary_key)
+  b$compact_seq = compact_seq
+
+  return(b)
+}

--- a/R/helper.R
+++ b/R/helper.R
@@ -54,12 +54,12 @@ format_sf = function(data) {
   }
 
   # extract spatial meta data
-  coordinates = as.data.frame(sf::st_coordinates(data))
+  coordinates = as.data.table(sf::st_coordinates(data))
 
   # convert sf to data.frame
   data[[attr(data, "sf_column")]] = NULL
   attr(data, "sf_column") = NULL
-  data = as.data.frame(data)
+  data = as.data.table(data)
 
   # add coordinates
   data = cbind(data, coordinates)

--- a/man/TaskClassifST.Rd
+++ b/man/TaskClassifST.Rd
@@ -18,8 +18,10 @@ changed by setting \code{coords_as_features = TRUE}.
 }
 \examples{
 if (mlr3misc::require_namespaces(c("sf", "blockCV"), quietly = TRUE)) {
-  task = as_task_classif_st(ecuador, target = "slides",
-    positive = "TRUE", coordinate_names = c("x", "y"))
+  task = as_task_classif_st(ecuador,
+    target = "slides",
+    positive = "TRUE", coordinate_names = c("x", "y")
+  )
 
   # passing objects of class 'sf' is also supported
   data_sf = sf::st_as_sf(ecuador, coords = c("x", "y"))


### PR DESCRIPTION
@be-marc 

I don't see how we can entirely omit custom code in the constructor while at the same time allowing `sf` objects to be handed over as the backend to `Task*$new()`?

`crs`, `coordinate_names` and `coordinates` need to be treated special within the constructor - no matter the backend (DT or SF).

I was able to outsource the helper fun `format_sf()` but I does not really have a practica  value and in fact just adds more code.

Am I overlooking something? How would you handle it?

I think we should definitely strive to allow passing `sf` objects when creating task via `$new()` and not only passing `sf` objects via the converters - otherwise this would be confusing for users. See also #203 for a backward comp issue.

Also with the new change, the test https://github.com/mlr-org/mlr3spatiotempcv/blob/main/tests/testthat/test-TaskRegrST.R#L49-L70 complains about a lot of attribute differences now :(