### PR TITLE
compatibility: mlr3 0.22.0

### DIFF
--- a/tests/testthat/test-TaskClassifST.R
+++ b/tests/testthat/test-TaskClassifST.R
@@ -14,7 +14,7 @@ test_that("printing works", {
 
 test_that("Supplying a non-spatio temporal task gives descriptive error message", {
   expect_error(
-    rsmp("spcv_coords")$instantiate(tsk("boston_housing")),
+    rsmp("spcv_coords")$instantiate(tsk("mtcars")),
     "Must inherit from class 'TaskClassifST' or 'TaskRegrST'."
   ) # nolint
 })


### PR DESCRIPTION
Compatibility patch for upcoming mlr3 0.22.0. We removed the boston housing dataset. Sorry I missed your package in the revdepchecks. I will upload mlr3 today. The update will not break mlr3spatiotempcv. Please upload the fix to CRAN in the next 2 weeks.