### PR TITLE
fix: use load_dataset for tasks

### DIFF
--- a/R/Task_classif_diplodia.R
+++ b/R/Task_classif_diplodia.R
@@ -26,7 +26,7 @@
 "diplodia"
 
 load_task_diplodia = function(id = "diplodia") {
-  b = mlr3::as_data_backend(diplodia)
+  b = mlr3::as_data_backend(mlr3misc::load_dataset("diplodia", "mlr3spatiotempcv"))
   b$hash = "_mlr3_tasks_diplodia_"
   task = TaskClassifST$new(
     id = "diplodia", b,

--- a/R/Task_classif_ecuador.R
+++ b/R/Task_classif_ecuador.R
@@ -26,7 +26,7 @@
 "ecuador"
 
 load_task_ecuador = function(id = "ecuador") {
-  b = mlr3::as_data_backend(ecuador)
+  b = mlr3::as_data_backend(mlr3misc::load_dataset("ecuador", "mlr3spatiotempcv"))
   b$hash = "_mlr3_tasks_ecuador_"
   task = TaskClassifST$new(
     id = "ecuador", b, target = "slides", positive = "TRUE",

--- a/R/Task_regr_cookfarm_profiles.R
+++ b/R/Task_regr_cookfarm_profiles.R
@@ -50,7 +50,7 @@
 "cookfarm_mlr3"
 
 load_task_cookfarm = function(id = "cookfarm_mlr3") {
-  b = mlr3::as_data_backend(cookfarm_mlr3)
+  b = mlr3::as_data_backend(mlr3misc::load_dataset("cookfarm_mlr3", "mlr3spatiotempcv"))
   b$hash = "_mlr3_tasks_cookfarm_"
   task = TaskRegrST$new(
     id = "cookfarm_mlr3", b, target = "PHIHOX",


### PR DESCRIPTION
When the namespace of `mlr3spatiotempcv` is loaded without attaching it `as.data.table(mlr_tasks)` fails.

```r
library(mlr3)
requireNamespace("mlr3spatiotempcv")
as.data.table(mlr_tasks)
Error in (function (id = "cookfarm_mlr3")  : 
  object 'cookfarm_mlr3' not found
```

