### PR TITLE
test: update tests for blockCV 4.0 (drop spatialBlock)

### DIFF
--- a/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
@@ -82,7 +82,7 @@ test_that("mlr3spatiotempcv indices are the same as blockCV indices: cols and ro
     cols = 4)
   suppressMessages(rsmp$instantiate(task))
 
-  testBlock_new = blockCV::cv_spatial(
+  testBlock = blockCV::cv_spatial(
     x = testSF,
     k = 4,
     rows_cols = c(3, 4),
@@ -94,20 +94,8 @@ test_that("mlr3spatiotempcv indices are the same as blockCV indices: cols and ro
     seed = 42
   )
 
-  testBlock_old = blockCV::spatialBlock(
-    speciesData = testSF,
-    k = 4,
-    rows = 3,
-    cols = 4,
-    showBlocks = FALSE,
-    progress = FALSE,
-    verbose = FALSE
-  )
-
-  # tempcv vs. blockCV_new  only use the first iteration
-  expect_equal(rsmp$instance$fold[1:1000], testBlock_new$folds_ids)
-  # tempcv vs. blockCV_old
-  expect_equal(rsmp$instance$fold[1:1000], testBlock_old$foldID)
+  # tempcv vs. blockCV  only use the first iteration
+  expect_equal(rsmp$instance$fold[1:1000], testBlock$folds_ids)
 })
 
 test_that("Error when selection = checkboard and folds > 2", {

--- a/tests/testthat/test-ResamplingSpCVBlock.R
+++ b/tests/testthat/test-ResamplingSpCVBlock.R
@@ -148,28 +148,8 @@ test_that("mlr3spatiotempcv indices are the same as blockCV indices: spatRaster"
       progress = FALSE
   ))
 
-  rl = terra::rast(terra::ext(testSF), crs = terra::crs(testSF))
-  vals = seq_len(terra::ncell(rl))
-  rl = terra::setValues(rl, vals)
-
-  set.seed(42)
-  # blockCV OLD
-  testBlock_old = suppressMessages(
-    blockCV::spatialBlock(
-      speciesData = testSF,
-      theRange = 50000L,
-      selection = "random",
-      rasterLayer = rl,
-      k = 2,
-      verbose = FALSE,
-      progress = FALSE,
-      showBlocks = FALSE
-  ))
-
-  # tempcv vs blockCV (NEW)
+  # tempcv vs blockCV
   expect_equal(rsmp1$instance$fold, testBlock$folds_ids)
-  # blockCV old vs blockCV NEW
-  expect_equal(testBlock_old$foldID, testBlock$folds_ids)
 })
 
 test_that("Error when selection = checkboard and folds > 2", {


### PR DESCRIPTION
Fixes #255.

blockCV 4.0 (CRAN submission planned for ~2026-08-20) removes the long-deprecated `blockCV::spatialBlock()`, which caused two test failures in the revdep checks:

- `test-ResamplingRepeatedSpCVBlock.R:97`
- `test-ResamplingSpCVBlock.R:157`

The package source already uses `blockCV::cv_spatial()` and reads the `folds_ids` element, so no changes to `R/` are needed. These tests additionally cross-checked the modern `cv_spatial()` output against the removed v2 `spatialBlock()` output. That comparison is obsolete once `spatialBlock()` is gone, so it is dropped; the tests still verify that mlr3spatiotempcv indices match `cv_spatial()`'s `folds_ids`.
