### PR TITLE
fix(resampling): require at least two folds for partitioning resamplings

### DIFF
--- a/R/ResamplingRepeatedSpCVBlock.R
+++ b/R/ResamplingRepeatedSpCVBlock.R
@@ -55,7 +55,7 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "repeated_spcv_block") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         repeats = p_int(lower = 1, tags = "required"),
         rows = p_int(lower = 1L),
         cols = p_int(lower = 1L),

--- a/R/ResamplingRepeatedSpCVCoords.R
+++ b/R/ResamplingRepeatedSpCVCoords.R
@@ -43,7 +43,7 @@ ResamplingRepeatedSpCVCoords = R6Class("ResamplingRepeatedSpCVCoords",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "repeated_spcv_coords") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         repeats = p_int(lower = 1, tags = "required")
       )
       ps$values = list(folds = 10L, repeats = 1)

--- a/R/ResamplingRepeatedSpCVEnv.R
+++ b/R/ResamplingRepeatedSpCVEnv.R
@@ -42,7 +42,7 @@ ResamplingRepeatedSpCVEnv = R6Class("ResamplingRepeatedSpCVEnv",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "repeated_spcv_env") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         repeats = p_int(lower = 1, tags = "required"),
         features = p_uty()
       )

--- a/R/ResamplingRepeatedSptCVCstf.R
+++ b/R/ResamplingRepeatedSptCVCstf.R
@@ -42,7 +42,7 @@ ResamplingRepeatedSptCVCstf = R6Class("ResamplingRepeatedSptCVCstf",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "repeated_sptcv_cstf") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         repeats = p_int(lower = 1, tags = "required"),
         stratify = p_lgl(default = FALSE)
       )

--- a/R/ResamplingSpCVBlock.R
+++ b/R/ResamplingSpCVBlock.R
@@ -45,7 +45,7 @@ ResamplingSpCVBlock = R6Class("ResamplingSpCVBlock",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "spcv_block") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         rows = p_int(lower = 1L),
         cols = p_int(lower = 1L),
         range = p_int(),

--- a/R/ResamplingSpCVCoords.R
+++ b/R/ResamplingSpCVCoords.R
@@ -35,7 +35,7 @@ ResamplingSpCVCoords = R6Class("ResamplingSpCVCoords",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "spcv_coords") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required")
+        folds = p_int(lower = 2L, tags = "required")
       )
       ps$values = list(folds = 10L)
       super$initialize(

--- a/R/ResamplingSpCVEnv.R
+++ b/R/ResamplingSpCVEnv.R
@@ -39,7 +39,7 @@ ResamplingSpCVEnv = R6Class("ResamplingSpCVEnv",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "spcv_env") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         features = p_uty()
       )
       ps$values = list(folds = 10L)

--- a/R/ResamplingSptCVCstf.R
+++ b/R/ResamplingSptCVCstf.R
@@ -37,7 +37,7 @@ ResamplingSptCVCstf = R6Class("ResamplingSptCVCstf",
     #'   Identifier for the resampling strategy.
     initialize = function(id = "sptcv_cstf") {
       ps = ps(
-        folds = p_int(lower = 1L, tags = "required"),
+        folds = p_int(lower = 2L, tags = "required"),
         stratify = p_lgl(default = FALSE)
       )
       ps$values = list(folds = 3L, stratify = FALSE)

--- a/tests/testthat/test-mlr_sptcv_generic.R
+++ b/tests/testthat/test-mlr_sptcv_generic.R
@@ -66,6 +66,34 @@ test_that("train and test set getter functions are working", {
   }
 })
 
+test_that("partitioning resamplings reject 'folds = 1'", {
+  # a single fold cannot be partitioned into train and test (#253)
+  keys = c(
+    "spcv_block", "spcv_coords", "spcv_env", "sptcv_cstf",
+    "repeated_spcv_block", "repeated_spcv_coords", "repeated_spcv_env",
+    "repeated_sptcv_cstf"
+  )
+
+  for (key in keys) {
+    # paradox reports the widened integer bound, so only match on the id
+    expect_error(rsmp(key, folds = 1), "folds")
+  }
+})
+
+test_that("'spcv_disc' allows 'folds = 1'", {
+  # here 'folds' is the number of sampled discs, not a partition of the data,
+  # so a single fold still yields a non-empty training set
+  task = test_make_twoclass_task()
+
+  # the test coordinates form a 6x6 grid with 1 m spacing
+  resampling = rsmp("spcv_disc", folds = 1, radius = 2, buffer = 1)
+  resampling$instantiate(task)
+
+  expect_equal(resampling$iters, 1)
+  expect_gt(length(resampling$train_set(1)), 0)
+  expect_gt(length(resampling$test_set(1)), 0)
+})
+
 test_that("cloning works", {
   skip_if_not_installed("skmeans")
 


### PR DESCRIPTION
Closes #253.

## Motivation

`folds = 1` cannot be partitioned into a training and a test set: the single fold becomes the test set and its complement is empty.
The resamplings accepted the value and silently returned an empty training set, as reported in #253:

```r
rcv = rsmp("sptcv_cstf", folds = 1)
rcv$instantiate(task)
length(rcv$train_set(1))
#> [1] 0
```

`mlr3::ResamplingCV` already guards against this with `folds = p_int(2L, tags = "required")`, and the two knndm resamplings in this package already used `lower = 2`.
The remaining resamplings were inconsistent with both.

## Changes

Raise the lower bound of `folds` from `1L` to `2L` in the eight k-fold partitioning resamplings:

- `R/ResamplingSpCVBlock.R`, `R/ResamplingRepeatedSpCVBlock.R`
- `R/ResamplingSpCVCoords.R`, `R/ResamplingRepeatedSpCVCoords.R`
- `R/ResamplingSpCVEnv.R`, `R/ResamplingRepeatedSpCVEnv.R`
- `R/ResamplingSptCVCstf.R`, `R/ResamplingRepeatedSptCVCstf.R`

`spcv_disc` and `repeated_spcv_disc` deliberately keep `lower = 1L`.
There `folds` is the number of sampled discs rather than a partition of the data: each iteration derives its training set independently as `di > radius + buffer`, so a single disc still yields a non-empty training set.

`R/ResamplingSpCVBuffer.R` and the tiles resamplings have no `folds` parameter and are untouched.

Add two tests to `tests/testthat/test-mlr_sptcv_generic.R` covering both sides of that distinction.

## Behaviour change

`rsmp(<key>, folds = 1)` now fails at construction instead of producing an unusable instance:

```r
rsmp("sptcv_cstf", folds = 1)
#> Error: Assertion on 'xs' failed: folds: Element 1 is not >= 1.5.
```

The `1.5` comes from how paradox reports widened integer bounds; it is the same message `mlr3::rsmp("cv", folds = 1)` produces, so the behaviour is consistent with core.
All existing defaults are `>= 3`, and no code, test, vignette or man page used `folds = 1`, so nothing else is affected.

## Verification

`R CMD INSTALL` plus `testthat::test_local()` on this branch.
`test-mlr_sptcv_generic.R` is fully green (48 passing, 0 skipped, 0 failures).

The full suite reports 4 errors, all of them missing optional packages in this environment and unrelated to this change: `patchwork`/`ggtext` for the two autoplot tests, and `mlr3spatial` for the two knndm tests.

Users who want an initial spatiotemporal train/test split (the reporter's actual goal) should use a single fold of a k-fold instance, e.g. `rsmp("sptcv_cstf", folds = 4)` with `train_set(1)` / `test_set(1)` for a 75/25 split.
