### PR TITLE
test: run tests serially to avoid leaking temp dirs on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,6 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/testthat/edition: 3
-Config/testthat/parallel: true
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: no


### PR DESCRIPTION
## Motivation

CRAN's *"for new files in some other directories"* check NOTEs on 2.3.4 with ~150 leftover `~/tmp/scratch/Rtmp*` directories.

## Root cause

The directories are R session temp dirs from testthat's parallel workers.

`testthat:::queue_teardown()` closes each worker's stdin, waits a **1 second** grace period, then unconditionally `kill_tree()`s every worker.
A killed `callr::r_session` never runs R's exit-time tempdir cleanup, so its `RtmpXXXXXXXX` directory survives in `TMPDIR` (which is `~/tmp/scratch` on the flagged check machine).
On a loaded check machine workers routinely miss the 1s window, and the leak accumulates across daily checks on every flavour.

This is testthat behaviour rather than a bug here, so opting out of parallel test running is the only reliable fix from this side.

## Changes

- `DESCRIPTION`: remove `Config/testthat/parallel: true`.

## Verification

Isolated `TMPDIR`, counting leftover `Rtmp*` directories after each run:

| Run | Leftovers |
| --- | --- |
| Killed `callr::r_session` (mechanism check) | 1 (survives `$kill()`) |
| Full suite, parallel, idle machine | 0 (window is wide enough) |
| Full suite, parallel, 32 busy loops on 12 cores | **2** |
| Full suite, serial, same load | **0** |
| `R CMD check`, serial | **0** |

Tests still pass serially: `FAIL 0 | WARN 0 | SKIP 4 | PASS 1333`.

## Behaviour change

Tests run serially, taking ~46s instead of ~28s on an idle machine.
That is well inside CRAN limits, so the speedup is not worth the NOTE.
No package code is affected.
