### PR TITLE
feat(spcv_block): expose blockCV fold balancing parameters

### DIFF
--- a/R/ResamplingRepeatedSpCVBlock.R
+++ b/R/ResamplingRepeatedSpCVBlock.R
@@ -66,6 +66,11 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
         selection = p_fct(levels = c(
           "random", "systematic",
           "checkerboard"), default = "random"),
+        balance = p_lgl(default = TRUE),
+        iteration = p_int(lower = 1L, default = 100L),
+        balance_on_target = p_lgl(default = FALSE),
+        num_bins = p_int(lower = 2L, default = 4L, special_vals = list(NULL)),
+        presence_bg = p_lgl(default = FALSE),
         rasterLayer = p_uty(
           default = NULL,
           custom_check = crate(function(x) {
@@ -174,7 +179,8 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
         task$row_ids,
         task$coordinates(),
         task$crs,
-        self$param_set$values$seed
+        self$param_set$values$seed,
+        blockcv_response(task, pv$balance_on_target, pv$presence_bg)
       )
 
       self$instance = instance
@@ -195,7 +201,7 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
     }
   ),
   private = list(
-    .sample = function(ids, coords, crs, seed) {
+    .sample = function(ids, coords, crs, seed, response = NULL) {
 
       pv = self$param_set$values
 
@@ -203,15 +209,24 @@ ResamplingRepeatedSpCVBlock = R6Class("ResamplingRepeatedSpCVBlock",
         points = sf::st_as_sf(coords,
           coords = colnames(coords),
           crs = crs)
+        if (!is.null(response)) {
+          points[[blockcv_col_name]] = response
+        }
 
         inds = blockCV::cv_spatial(
           x = points,
+          column = if (is.null(response)) NULL else blockcv_col_name,
           size = range,
-          rows_cols = c(self$param_set$values$rows, self$param_set$values$cols),
-          k = self$param_set$values$folds,
-          r = self$param_set$values$rasterLayer,
-          selection = self$param_set$values$selection,
-          hexagon = self$param_set$values$hexagon,
+          rows_cols = c(pv$rows, pv$cols),
+          k = pv$folds,
+          r = pv$rasterLayer,
+          selection = pv$selection,
+          hexagon = pv$hexagon,
+          balance = pv$balance %??% TRUE,
+          iteration = pv$iteration %??% 100L,
+          # 'NULL' is a valid user setting for 'num_bins', hence check the name
+          num_bins = if ("num_bins" %in% names(pv)) pv$num_bins else 4L,
+          presence_bg = pv$presence_bg %??% FALSE,
           plot = FALSE,
           verbose = FALSE,
           report = FALSE,

--- a/R/ResamplingSpCVBlock.R
+++ b/R/ResamplingSpCVBlock.R
@@ -54,6 +54,11 @@ ResamplingSpCVBlock = R6Class("ResamplingSpCVBlock",
         selection = p_fct(levels = c(
           "random", "systematic",
           "checkerboard"), default = "random"),
+        balance = p_lgl(default = TRUE),
+        iteration = p_int(lower = 1L, default = 100L),
+        balance_on_target = p_lgl(default = FALSE),
+        num_bins = p_int(lower = 2L, default = 4L, special_vals = list(NULL)),
+        presence_bg = p_lgl(default = FALSE),
         rasterLayer = p_uty(
           default = NULL,
           custom_check = crate(function(x) {
@@ -134,7 +139,8 @@ ResamplingSpCVBlock = R6Class("ResamplingSpCVBlock",
         task$row_ids,
         task$coordinates(),
         task$crs,
-        self$param_set$values$seed
+        self$param_set$values$seed,
+        blockcv_response(task, pv$balance_on_target, pv$presence_bg)
       )
 
       self$instance = instance
@@ -153,22 +159,33 @@ ResamplingSpCVBlock = R6Class("ResamplingSpCVBlock",
     }
   ),
   private = list(
-    .sample = function(ids, coords, crs, seed) {
+    .sample = function(ids, coords, crs, seed, response = NULL) {
+
+      pv = self$param_set$values
 
       points = sf::st_as_sf(coords,
         coords = colnames(coords),
         crs = crs
       )
+      if (!is.null(response)) {
+        points[[blockcv_col_name]] = response
+      }
       # Suppress print message, warning crs and package load
       # Note: Do not replace the assignment operator here.
       inds = blockCV::cv_spatial(
         x = points,
-        size = self$param_set$values$range,
-        rows_cols = c(self$param_set$values$rows, self$param_set$values$cols),
-        k = self$param_set$values$folds,
-        r = self$param_set$values$rasterLayer,
-        selection = self$param_set$values$selection,
-        hexagon = self$param_set$values$hexagon,
+        column = if (is.null(response)) NULL else blockcv_col_name,
+        size = pv$range,
+        rows_cols = c(pv$rows, pv$cols),
+        k = pv$folds,
+        r = pv$rasterLayer,
+        selection = pv$selection,
+        hexagon = pv$hexagon,
+        balance = pv$balance %??% TRUE,
+        iteration = pv$iteration %??% 100L,
+        # 'NULL' is a valid user setting for 'num_bins', hence check the name
+        num_bins = if ("num_bins" %in% names(pv)) pv$num_bins else 4L,
+        presence_bg = pv$presence_bg %??% FALSE,
         plot = FALSE,
         progress = FALSE,
         report = FALSE,

--- a/R/helper.R
+++ b/R/helper.R
@@ -20,3 +20,41 @@ format_sf = function(data) {
   data = cbind(data, coordinates)
   return(data)
 }
+
+# Name of the column which carries the task target into the 'sf' object handed
+# to blockCV::cv_spatial(). Fixed (and not the target name) to rule out a clash
+# with the geometry column.
+blockcv_col_name = "mlr3_target"
+
+# Extracts the task target for response-aware fold balancing in
+# blockCV::cv_spatial(). Returns `NULL` when balancing on the target was not
+# requested, in which case blockCV balances the total number of records.
+blockcv_response = function(task, balance_on_target, presence_bg) {
+  if (!isTRUE(balance_on_target)) {
+    if (isTRUE(presence_bg)) {
+      stopf("'presence_bg = TRUE' requires 'balance_on_target = TRUE': blockCV
+        needs the task target to tell presences from background points.",
+        wrap = TRUE)
+    }
+    return(NULL)
+  }
+
+  values = task$data(rows = task$row_ids, cols = task$target_names)[[1L]]
+
+  if (!isTRUE(presence_bg)) {
+    return(values)
+  }
+
+  # blockCV expects presence-background data as a binary numeric column with 1s
+  # for presences and 0s for background points. Translate two-class factor
+  # targets via the positive class of the task.
+  if (is.factor(values)) {
+    if (nlevels(values) != 2L) {
+      stopf("'presence_bg = TRUE' requires a two-class target, but target '%s'
+        has %i levels.", task$target_names, nlevels(values), wrap = TRUE)
+    }
+    values = as.integer(values == task$positive)
+  }
+
+  values
+}

--- a/man-roxygen/rox_spcv_block.R
+++ b/man-roxygen/rox_spcv_block.R
@@ -25,3 +25,42 @@
 #' - `cols` and `rows` -> `rows_cols`
 #'
 #' The default of argument `hexagon` is different in `mlr3spatiotempcv` (`FALSE` instead of `TRUE`) to create square blocks instead of hexagonal blocks by default.
+#'
+#' @section Fold balancing:
+#'
+#' [blockCV::cv_spatial()] assigns blocks to folds by drawing `iteration`
+#' random candidate assignments and keeping the most balanced one.
+#' All balancing parameters only take effect for `selection = "random"`.
+#'
+#' By default the balancing objective is the total number of observations per
+#' fold, which is what `mlr3spatiotempcv` has always used.
+#' Setting `balance_on_target = TRUE` passes the target of the task to argument
+#' `column` of [blockCV::cv_spatial()], which balances the response classes
+#' (or the quantile bins of a continuous response) across the folds instead.
+#' This is opt-in to keep the default fold assignment unchanged.
+#'
+#' @section Parameters:
+#'
+#' * `balance` (`logical(1)`)\cr
+#'   Search `iteration` random block-to-fold assignments for a balanced one.
+#'   If `FALSE`, a single random assignment is used.
+#'   Default: `TRUE`.
+#' * `iteration` (`integer(1)`)\cr
+#'   Number of candidate assignments evaluated during the balancing search.
+#'   Default: `100`.
+#' * `balance_on_target` (`logical(1)`)\cr
+#'   Balance the classes (or quantile bins) of the task target across folds
+#'   instead of the plain number of observations.
+#'   Default: `FALSE`.
+#' * `num_bins` (`integer(1)`)\cr
+#'   Number of quantile bins a continuous target is stratified into before
+#'   balancing. Only relevant with `balance_on_target = TRUE`.
+#'   Set to `NULL` to treat every unique value as its own class.
+#'   Default: `4`.
+#' * `presence_bg` (`logical(1)`)\cr
+#'   Treat the target as presence-background data, i.e. balance only the
+#'   presence records so that the abundant background points cannot dominate
+#'   the objective. Requires `balance_on_target = TRUE`.
+#'   For a two-class [TaskClassifST] the positive class of the task is used as
+#'   the presence class, a numeric target must consist of `0`s and `1`s.
+#'   Default: `FALSE`.

--- a/man/mlr_resamplings_repeated_spcv_block.Rd
+++ b/man/mlr_resamplings_repeated_spcv_block.Rd
@@ -67,7 +67,49 @@ Here's a list which shows the mapping between \code{blockCV} < 3.0.0 and \code{b
 The default of argument \code{hexagon} is different in \code{mlr3spatiotempcv} (\code{FALSE} instead of \code{TRUE}) to create square blocks instead of hexagonal blocks by default.
 }
 
+\section{Fold balancing}{
+
+
+\code{\link[blockCV:cv_spatial]{blockCV::cv_spatial()}} assigns blocks to folds by drawing \code{iteration}
+random candidate assignments and keeping the most balanced one.
+All balancing parameters only take effect for \code{selection = "random"}.
+
+By default the balancing objective is the total number of observations per
+fold, which is what \code{mlr3spatiotempcv} has always used.
+Setting \code{balance_on_target = TRUE} passes the target of the task to argument
+\code{column} of \code{\link[blockCV:cv_spatial]{blockCV::cv_spatial()}}, which balances the response classes
+(or the quantile bins of a continuous response) across the folds instead.
+This is opt-in to keep the default fold assignment unchanged.
+}
+
 \section{Parameters}{
+
+\itemize{
+\item \code{balance} (\code{logical(1)})\cr
+Search \code{iteration} random block-to-fold assignments for a balanced one.
+If \code{FALSE}, a single random assignment is used.
+Default: \code{TRUE}.
+\item \code{iteration} (\code{integer(1)})\cr
+Number of candidate assignments evaluated during the balancing search.
+Default: \code{100}.
+\item \code{balance_on_target} (\code{logical(1)})\cr
+Balance the classes (or quantile bins) of the task target across folds
+instead of the plain number of observations.
+Default: \code{FALSE}.
+\item \code{num_bins} (\code{integer(1)})\cr
+Number of quantile bins a continuous target is stratified into before
+balancing. Only relevant with \code{balance_on_target = TRUE}.
+Set to \code{NULL} to treat every unique value as its own class.
+Default: \code{4}.
+\item \code{presence_bg} (\code{logical(1)})\cr
+Treat the target as presence-background data, i.e. balance only the
+presence records so that the abundant background points cannot dominate
+the objective. Requires \code{balance_on_target = TRUE}.
+For a two-class \link{TaskClassifST} the positive class of the task is used as
+the presence class, a numeric target must consist of \code{0}s and \code{1}s.
+Default: \code{FALSE}.
+}
+
 
 \itemize{
 \item \code{repeats} (\code{integer(1)})\cr

--- a/man/mlr_resamplings_spcv_block.Rd
+++ b/man/mlr_resamplings_spcv_block.Rd
@@ -67,6 +67,50 @@ Here's a list which shows the mapping between \code{blockCV} < 3.0.0 and \code{b
 The default of argument \code{hexagon} is different in \code{mlr3spatiotempcv} (\code{FALSE} instead of \code{TRUE}) to create square blocks instead of hexagonal blocks by default.
 }
 
+\section{Fold balancing}{
+
+
+\code{\link[blockCV:cv_spatial]{blockCV::cv_spatial()}} assigns blocks to folds by drawing \code{iteration}
+random candidate assignments and keeping the most balanced one.
+All balancing parameters only take effect for \code{selection = "random"}.
+
+By default the balancing objective is the total number of observations per
+fold, which is what \code{mlr3spatiotempcv} has always used.
+Setting \code{balance_on_target = TRUE} passes the target of the task to argument
+\code{column} of \code{\link[blockCV:cv_spatial]{blockCV::cv_spatial()}}, which balances the response classes
+(or the quantile bins of a continuous response) across the folds instead.
+This is opt-in to keep the default fold assignment unchanged.
+}
+
+\section{Parameters}{
+
+\itemize{
+\item \code{balance} (\code{logical(1)})\cr
+Search \code{iteration} random block-to-fold assignments for a balanced one.
+If \code{FALSE}, a single random assignment is used.
+Default: \code{TRUE}.
+\item \code{iteration} (\code{integer(1)})\cr
+Number of candidate assignments evaluated during the balancing search.
+Default: \code{100}.
+\item \code{balance_on_target} (\code{logical(1)})\cr
+Balance the classes (or quantile bins) of the task target across folds
+instead of the plain number of observations.
+Default: \code{FALSE}.
+\item \code{num_bins} (\code{integer(1)})\cr
+Number of quantile bins a continuous target is stratified into before
+balancing. Only relevant with \code{balance_on_target = TRUE}.
+Set to \code{NULL} to treat every unique value as its own class.
+Default: \code{4}.
+\item \code{presence_bg} (\code{logical(1)})\cr
+Treat the target as presence-background data, i.e. balance only the
+presence records so that the abundant background points cannot dominate
+the objective. Requires \code{balance_on_target = TRUE}.
+For a two-class \link{TaskClassifST} the positive class of the task is used as
+the presence class, a numeric target must consist of \code{0}s and \code{1}s.
+Default: \code{FALSE}.
+}
+}
+
 \examples{
 \donttest{
 if (mlr3misc::require_namespaces(c("sf", "blockCV"), quietly = TRUE)) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -165,6 +165,74 @@ test_make_blockCV_test_task = function() {
   return(task)
 }
 
+# sf DF with an imbalanced presence-background response (~10% presences) to use
+# directly with {blockCV} functions
+test_make_blockCV_pb_test_df = function() {
+  set.seed(123)
+  x = runif(1000, -80.4, -74)
+  y = runif(1000, 39.6, 41)
+
+  data = data.frame(
+    spp = "test",
+    occ = factor(as.integer(runif(length(x)) < 0.1)),
+    x = x,
+    y = y
+  )
+
+  data_sf = sf::st_as_sf(data,
+    coords = c("x", "y"),
+    crs = "EPSG:4326"
+  )
+
+  return(data_sf)
+}
+
+# mlr3 task to compare mlr3spatiotempcv results with {blockCV} results
+test_make_blockCV_pb_test_task = function() {
+  data = test_make_blockCV_pb_test_df()
+
+  task = as_task_classif_st(
+    data,
+    id = "test",
+    target = "occ",
+    positive = "1"
+  )
+  return(task)
+}
+
+# sf DF with a continuous response to use directly with {blockCV} functions
+test_make_blockCV_regr_test_df = function() {
+  set.seed(123)
+  x = runif(1000, -80.4, -74)
+  y = runif(1000, 39.6, 41)
+
+  data = data.frame(
+    spp = "test",
+    response = rnorm(length(x)),
+    x = x,
+    y = y
+  )
+
+  data_sf = sf::st_as_sf(data,
+    coords = c("x", "y"),
+    crs = "EPSG:4326"
+  )
+
+  return(data_sf)
+}
+
+# mlr3 task to compare mlr3spatiotempcv results with {blockCV} results
+test_make_blockCV_regr_test_task = function() {
+  data = test_make_blockCV_regr_test_df()
+
+  task = as_task_regr_st(
+    data,
+    id = "test",
+    target = "response"
+  )
+  return(task)
+}
+
 # mlr3 task to compare mlr3spatiotempcv results with {blockCV} results
 test_make_knndm_test_task = function() {
   data = test_make_blockCV_test_df()

--- a/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
+++ b/tests/testthat/test-ResamplingRepeatedSpCVBlock.R
@@ -105,3 +105,51 @@ test_that("Error when selection = checkboard and folds > 2", {
   expect_error(rsmp("repeated_spcv_block", range = 10000L,
     selection = "checkerboard", folds = 5)$instantiate(task))
 })
+
+test_that("balance_on_target passes the task target to blockCV", {
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  testSF = test_make_blockCV_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("repeated_spcv_block",
+    repeats = 2,
+    folds = 4,
+    rows = 3,
+    cols = 4,
+    seed = 42,
+    balance_on_target = TRUE)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    column = "label",
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    report = FALSE,
+    plot = FALSE,
+    verbose = FALSE,
+    progress = FALSE,
+    seed = 42
+  ))
+
+  # only compare the first repetition
+  expect_equal(rsp$instance$fold[1:1000], testBlock$folds_ids)
+})
+
+test_that("error when presence_bg is set without balance_on_target", {
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  rsp = rsmp("repeated_spcv_block",
+    repeats = 1, folds = 4, rows = 3, cols = 4, presence_bg = TRUE)
+
+  expect_error(
+    rsp$instantiate(task),
+    "requires 'balance_on_target = TRUE'",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-ResamplingSpCVBlock.R
+++ b/tests/testthat/test-ResamplingSpCVBlock.R
@@ -158,3 +158,219 @@ test_that("Error when selection = checkboard and folds > 2", {
   expect_error(rsmp("spcv_block", range = 10000L,
     selection = "checkerboard", folds = 5)$instantiate(task))
 })
+
+test_that("fold balancing defaults do not change the fold assignment", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  testSF = test_make_blockCV_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block", folds = 4, rows = 3, cols = 4, seed = 42)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    plot = FALSE,
+    report = FALSE,
+    progress = FALSE,
+    verbose = FALSE,
+    seed = 42
+  ))
+
+  expect_equal(rsp$instance$fold, testBlock$folds_ids)
+})
+
+test_that("balance_on_target passes the task target to blockCV", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  testSF = test_make_blockCV_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block",
+    folds = 4, rows = 3, cols = 4, seed = 42,
+    balance_on_target = TRUE)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    column = "label",
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    plot = FALSE,
+    report = FALSE,
+    progress = FALSE,
+    verbose = FALSE,
+    seed = 42
+  ))
+
+  expect_equal(rsp$instance$fold, testBlock$folds_ids)
+})
+
+test_that("balance = FALSE skips the balancing search", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  testSF = test_make_blockCV_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block",
+    folds = 4, rows = 3, cols = 4, seed = 42,
+    balance = FALSE)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    balance = FALSE,
+    plot = FALSE,
+    report = FALSE,
+    progress = FALSE,
+    verbose = FALSE,
+    seed = 42
+  ))
+
+  expect_equal(rsp$instance$fold, testBlock$folds_ids)
+})
+
+test_that("iteration is passed to the balancing search", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  testSF = test_make_blockCV_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block",
+    folds = 4, rows = 3, cols = 4, seed = 42,
+    iteration = 5L)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    iteration = 5L,
+    plot = FALSE,
+    report = FALSE,
+    progress = FALSE,
+    verbose = FALSE,
+    seed = 42
+  ))
+
+  expect_equal(rsp$instance$fold, testBlock$folds_ids)
+})
+
+test_that("presence_bg translates a two-class target to presence-background", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_pb_test_task()
+  testSF = test_make_blockCV_pb_test_df()
+  # blockCV wants the presences as numeric 1s, the task target is a factor with
+  # the positive class "1"
+  testSF$presence = as.integer(testSF$occ == "1")
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block",
+    folds = 4, rows = 3, cols = 4, seed = 42,
+    balance_on_target = TRUE, presence_bg = TRUE)
+  suppressWarnings(suppressMessages(rsp$instantiate(task)))
+
+  cv_spatial_pb = function(presence_bg) {
+    suppressWarnings(suppressMessages(blockCV::cv_spatial(
+      x = testSF,
+      column = "presence",
+      presence_bg = presence_bg,
+      k = 4,
+      rows_cols = c(3, 4),
+      hexagon = FALSE,
+      plot = FALSE,
+      report = FALSE,
+      progress = FALSE,
+      verbose = FALSE,
+      seed = 42
+    )))
+  }
+
+  expect_equal(rsp$instance$fold, cv_spatial_pb(TRUE)$folds_ids)
+  # guard against 'presence_bg' silently not being passed on
+  expect_false(identical(rsp$instance$fold, cv_spatial_pb(FALSE)$folds_ids))
+})
+
+test_that("num_bins is passed on for continuous targets", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_regr_test_task()
+  testSF = test_make_blockCV_regr_test_df()
+
+  sf::sf_use_s2(use_s2 = FALSE)
+
+  rsp = rsmp("spcv_block",
+    folds = 4, rows = 3, cols = 4, seed = 42,
+    balance_on_target = TRUE, num_bins = 2L)
+  suppressMessages(rsp$instantiate(task))
+
+  testBlock = suppressMessages(blockCV::cv_spatial(
+    x = testSF,
+    column = "response",
+    num_bins = 2L,
+    k = 4,
+    rows_cols = c(3, 4),
+    hexagon = FALSE,
+    plot = FALSE,
+    report = FALSE,
+    progress = FALSE,
+    verbose = FALSE,
+    seed = 42
+  ))
+
+  expect_equal(rsp$instance$fold, testBlock$folds_ids)
+})
+
+test_that("error when presence_bg is set without balance_on_target", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_blockCV_test_task()
+  rsp = rsmp("spcv_block", folds = 4, rows = 3, cols = 4, presence_bg = TRUE)
+
+  expect_error(
+    rsp$instantiate(task),
+    "requires 'balance_on_target = TRUE'",
+    fixed = TRUE
+  )
+})
+
+test_that("error when presence_bg is used with a multiclass target", {
+  skip_if_not_installed("sf")
+  skip_if_not_installed("blockCV")
+
+  task = test_make_multiclass()
+  rsp = rsmp("spcv_block",
+    folds = 2, range = 2L,
+    balance_on_target = TRUE, presence_bg = TRUE)
+
+  expect_error(
+    rsp$instantiate(task),
+    "requires a two-class target",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Implements PR A from #257: expose the fold balancing of `blockCV::cv_spatial()` on `spcv_block` and `repeated_spcv_block`.

Both resamplings called `cv_spatial()` with a fixed argument list and no `...` passthrough, so none of the balancing knobs were reachable.

## New parameters

| Parameter | Default | Description |
| --- | --- | --- |
| `balance` | `TRUE` | Search `iteration` random block-to-fold assignments for a balanced one. `FALSE` uses a single random assignment. |
| `iteration` | `100` | Number of candidate assignments evaluated during the search. |
| `balance_on_target` | `FALSE` | Balance the classes (or quantile bins) of the task target instead of the plain number of observations. |
| `num_bins` | `4` | Quantile bins a continuous target is stratified into. `NULL` treats every unique value as its own class. |
| `presence_bg` | `FALSE` | Balance only the presence records so the background cannot dominate the objective. |

All of them only take effect for `selection = "random"`.

## Response-aware balancing is opt-in

As @rvalavi pointed out in #257, `num_bins` and `presence_bg` do nothing unless the response is passed to `cv_spatial(column = )`, and passing it by default would change the objective from "balance total records" to "balance response classes".

`balance_on_target = TRUE` therefore opts into it explicitly and injects the task target into the `sf` object handed to blockCV. The default is unchanged, so existing fold assignments stay identical.

For `presence_bg`, blockCV wants a binary numeric `0`/`1` column, whereas an mlr3 classification target is a factor. A two-class target is translated using `task$positive` (positive class → `1`); a multiclass target errors, as does `presence_bg` without `balance_on_target`.

## Note: requires blockCV >= 4.0.0

`balance`, `num_bins` and `presence_bg` were added in blockCV 4.0.0, which is not on CRAN yet. `DESCRIPTION` is deliberately left at `blockCV (>= 3.1.2)` and no `Remotes` entry is added, so this is worth knowing:

- Against blockCV 3.x these three arguments are silently swallowed by the upstream `...`, i.e. they become no-ops rather than errors. `balance_on_target` and `iteration` work on 3.x.
- Until blockCV 4.0.0 is available to CI, the `presence_bg` test fails there. Everything else passes on both versions. Happy to add a `skip_if_not_installed("blockCV", "4.0.0")` to that test if a green run is wanted in the meantime.

## Tests

8 new tests, each comparing the resulting folds against a direct `blockCV::cv_spatial()` call with the corresponding argument, plus error cases. The `presence_bg` test uses a new imbalanced (~10% presence) helper task and additionally asserts the result *differs* from `presence_bg = FALSE`, so a dropped argument cannot pass unnoticed.

Verified locally against blockCV 4.0.0 (`rvalavi/blockCV@908b4a0`): full suite 1240 passed, 0 failed, 0 warnings, 23 skipped for missing optional suggests.

## Out of scope

PR B (switching `SpCVEnv` to `blockCV::cv_cluster()` for `spatial_weight`) is untouched and stays open in #257.
